### PR TITLE
Release v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to `laravel-love` will be documented in this file.
 
+## [5.0.0] - 2018-01-11
+
+### Added
+
+- Added `Cog\Contracts\Love\Liker\Models\Liker` contract with methods `like`, `dislike`, `unlike`, `undislike`, `toggleLike`, `toggleDislike`, `hasLiked`, `hasDisliked`
+
+### Changed
+
+- Method `like` renamed to `likeBy` in `Cog\Contracts\Love\Likeable\Models\Likeable` contract
+- Method `dislike` renamed to `dislikeBy` in `Cog\Contracts\Love\Likeable\Models\Likeable` contract
+- Method `unlike` renamed to `unlikeBy` in `Cog\Contracts\Love\Likeable\Models\Likeable` contract
+- Method `undislike` renamed to `undislikeBy` in `Cog\Contracts\Love\Likeable\Models\Likeable` contract
+- Method `liked` renamed to `likedBy` in `Cog\Contracts\Love\Likeable\Models\Likeable` contract
+- Method `disliked` renamed to `dislikedBy` in `Cog\Contracts\Love\Likeable\Models\Likeable` contract
+- Method `likeToggle` renamed to `toggleLikeBy` in `Cog\Contracts\Love\Likeable\Models\Likeable` contract
+- Method `dislikeToggle` renamed to `toggleDislikeBy` in `Cog\Contracts\Love\Likeable\Models\Likeable` contract
+
 ## [4.0.0] - 2018-01-04
 
 ### Changed
@@ -149,6 +166,7 @@ All notable changes to `laravel-love` will be documented in this file.
 
 - Initial release
 
+[5.0.0]: https://github.com/cybercog/laravel-love/compare/4.0.0...5.0.0
 [4.0.0]: https://github.com/cybercog/laravel-love/compare/3.1.0...4.0.0
 [3.1.0]: https://github.com/cybercog/laravel-love/compare/3.0.0...3.1.0
 [3.0.0]: https://github.com/cybercog/laravel-love/compare/2.2.5...3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `laravel-love` will be documented in this file.
 
-## [5.0.0] - 2018-01-11
+## [5.0.0] - 2018-01-16
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ It completely changes package namespace architecture, aimed to API refactoring a
 - [Features](#features)
 - [Installation](#installation)
 - [Usage](#usage)
-  - [Prepare likeable model](#prepare-likeable-model)
-  - [Available methods](#available-methods)
+  - [Prepare Liker Model](#prepare-liker-model)
+  - [Prepare Likeable Model](#prepare-likeable-model)
+  - [Available Methods](#available-methods)
   - [Scopes](#scopes)
   - [Events](#events)
-  - [Console commands](#console-commands)
+  - [Console Commands](#console-commands)
 - [Extending](#extending)
-- [Change log](#change-log)
+- [Changelog](#changelog)
 - [Upgrading](#upgrading)
 - [Contributing](#contributing)
 - [Testing](#testing)
@@ -78,9 +79,26 @@ $ php artisan vendor:publish --provider="Cog\Laravel\Love\Providers\LoveServiceP
 
 ## Usage
 
-### Prepare likeable model
+### Prepare Liker Model
 
-Use `Likeable` contract in model which will get likes behavior and implement it or just use `Likeable` trait. 
+Use `Cog\Contracts\Love\Liker\Models\Liker` contract in model which will get likes
+behavior and implement it or just use `Cog\Laravel\Love\Liker\Models\Traits\Liker` trait. 
+
+```php
+use Cog\Contracts\Love\Liker\Models\Liker as LikerContract;
+use Cog\Laravel\Love\Liker\Models\Traits\Liker;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable implements LikerContract
+{
+    use Liker;
+}
+```
+
+### Prepare Likeable Model
+
+Use `Cog\Contracts\Love\Likeable\Models\Likeable` contract in model which will get likes
+behavior and implement it or just use `Cog\Laravel\Love\Likeable\Models\Traits\Likeable` trait. 
 
 ```php
 use Cog\Contracts\Love\Likeable\Models\Likeable as LikeableContract;
@@ -93,29 +111,36 @@ class Article extends Model implements LikeableContract
 }
 ```
 
-### Available methods
+### Available Methods
 
 #### Likes
 
 ##### Like model
 
+
 ```php
-$article->like(); // current user
-$article->like($user->id);
+$user->like($article);
+
+$article->likeBy(); // current user
+$article->likeBy($user->id);
 ```
 
 ##### Remove like mark from model
 
 ```php
-$article->unlike(); // current user
-$article->unlike($user->id);
+$user->unlike($article);
+
+$article->unlikeBy(); // current user
+$article->unlikeBy($user->id);
 ```
 
 ##### Toggle like mark of model
 
 ```php
-$article->likeToggle(); // current user
-$article->likeToggle($user->id);
+$user->toggleLike($article);
+
+$article->toggleLikeBy(); // current user
+$article->toggleLikeBy($user->id);
 ```
 
 ##### Get model likes count
@@ -145,9 +170,11 @@ $article->likes;
 ##### Boolean check if user liked model
 
 ```php
+$user->hasLiked($article);
+
 $article->liked; // current user
-$article->liked(); // current user
-$article->liked($user->id);
+$article->isLikedBy(); // current user
+$article->isLikedBy($user->id);
 ```
 
 *Checks in eager loaded relations `likes` & `likesAndDislikes` first.*
@@ -169,22 +196,28 @@ $article->removeLikes();
 ##### Dislike model
 
 ```php
-$article->dislike(); // current user
-$article->dislike($user->id);
+$user->dislike($article);
+
+$article->dislikeBy(); // current user
+$article->dislikeBy($user->id);
 ```
 
 ##### Remove dislike mark from model
 
 ```php
-$article->undislike(); // current user
-$article->undislike($user->id);
+$user->undislike($article);
+
+$article->undislikeBy(); // current user
+$article->undislikeBy($user->id);
 ```
 
 ##### Toggle dislike mark of model
 
 ```php
-$article->dislikeToggle(); // current user
-$article->dislikeToggle($user->id);
+$user->toggleDislike($article);
+
+$article->toggleDislikeBy(); // current user
+$article->toggleDislikeBy($user->id);
 ```
 
 ##### Get model dislikes count
@@ -214,9 +247,11 @@ $article->dislikes;
 ##### Boolean check if user disliked model
 
 ```php
+$user->hasDisliked($article);
+
 $article->disliked; // current user
-$article->disliked(); // current user
-$article->disliked($user->id);
+$article->isDislikedBy(); // current user
+$article->isDislikedBy($user->id);
 ```
 
 *Checks in eager loaded relations `dislikes` & `likesAndDislikes` first.*
@@ -299,7 +334,7 @@ On each dislike added `\Cog\Laravel\Love\Likeable\Events\LikeableWasDisliked` ev
 
 On each dislike removed `\Cog\Laravel\Love\Likeable\Events\LikeableWasUndisliked` event is fired.
 
-### Console commands
+### Console Commands
 
 ##### Recount likes and dislikes of all model types
 
@@ -392,7 +427,7 @@ $model = app(\Cog\Contracts\Love\Like\Models\Like::class);
 $service = app(\Cog\Contracts\Love\Likeable\Services\LikeableService::class);
 ```
 
-## Change log
+## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,20 @@
 # Upgrade Guide
 
+- [From v4 to v5](#from-v4-to-v5)
 - [From v3 to v4](#from-v3-to-v4)
+
+## From v4 to v5
+
+### Likeable model methods
+
+- Find all `like` method and replace it with `likeBy`
+- Find all `dislike` method and replace it with `dislikeBy`
+- Find all `unlike` method and replace it with `unlikeBy`
+- Find all `undislike` method and replace it with `undislikeBy`
+- Find all `likeToggle` method and replace it with `toggleLikeBy`
+- Find all `dislikeToggle` method and replace it with `toggleDislikeBy`
+- Find all `liked` method and replace it with `isLikedBy`
+- Find all `disliked` method and replace it with `isDislikedBy`
 
 ## From v3 to v4
 

--- a/contracts/Likeable/Models/Likeable.php
+++ b/contracts/Likeable/Models/Likeable.php
@@ -93,7 +93,7 @@ interface Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function like($userId = null);
+    public function likeBy($userId = null);
 
     /**
      * Remove a like from this record for the given user.
@@ -103,7 +103,7 @@ interface Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function unlike($userId = null);
+    public function unlikeBy($userId = null);
 
     /**
      * Toggle like for model by the given user.
@@ -113,7 +113,7 @@ interface Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function likeToggle($userId = null);
+    public function toggleLikeBy($userId = null);
 
     /**
      * Has the user already liked likeable model.
@@ -121,7 +121,7 @@ interface Likeable
      * @param null|string|int $userId
      * @return bool
      */
-    public function liked($userId = null): bool;
+    public function isLikedBy($userId = null): bool;
 
     /**
      * Delete likes related to the current record.
@@ -138,7 +138,7 @@ interface Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function dislike($userId = null);
+    public function dislikeBy($userId = null);
 
     /**
      * Remove a dislike from this record for the given user.
@@ -148,7 +148,7 @@ interface Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function undislike($userId = null);
+    public function undislikeBy($userId = null);
 
     /**
      * Toggle dislike for model by the given user.
@@ -158,7 +158,7 @@ interface Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function dislikeToggle($userId = null);
+    public function toggleDislikeBy($userId = null);
 
     /**
      * Has the user already disliked likeable model.
@@ -166,7 +166,7 @@ interface Likeable
      * @param null|string|int $userId
      * @return bool
      */
-    public function disliked($userId = null): bool;
+    public function isDislikedBy($userId = null): bool;
 
     /**
      * Delete dislikes related to the current record.

--- a/contracts/Likeable/Models/Likeable.php
+++ b/contracts/Likeable/Models/Likeable.php
@@ -96,41 +96,6 @@ interface Likeable
     public function likeBy($userId = null);
 
     /**
-     * Remove a like from this record for the given user.
-     *
-     * @param null|string|int $userId If null will use currently logged in user.
-     * @return void
-     *
-     * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
-     */
-    public function unlikeBy($userId = null);
-
-    /**
-     * Toggle like for model by the given user.
-     *
-     * @param null|string|int $userId If null will use currently logged in user.
-     * @return void
-     *
-     * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
-     */
-    public function toggleLikeBy($userId = null);
-
-    /**
-     * Has the user already liked likeable model.
-     *
-     * @param null|string|int $userId
-     * @return bool
-     */
-    public function isLikedBy($userId = null): bool;
-
-    /**
-     * Delete likes related to the current record.
-     *
-     * @return void
-     */
-    public function removeLikes();
-
-    /**
      * Add a dislike for model by the given user.
      *
      * @param null|string|int $userId If null will use currently logged in user.
@@ -139,6 +104,16 @@ interface Likeable
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
     public function dislikeBy($userId = null);
+
+    /**
+     * Remove a like from this record for the given user.
+     *
+     * @param null|string|int $userId If null will use currently logged in user.
+     * @return void
+     *
+     * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
+     */
+    public function unlikeBy($userId = null);
 
     /**
      * Remove a dislike from this record for the given user.
@@ -151,6 +126,16 @@ interface Likeable
     public function undislikeBy($userId = null);
 
     /**
+     * Toggle like for model by the given user.
+     *
+     * @param null|string|int $userId If null will use currently logged in user.
+     * @return void
+     *
+     * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
+     */
+    public function toggleLikeBy($userId = null);
+
+    /**
      * Toggle dislike for model by the given user.
      *
      * @param null|string|int $userId If null will use currently logged in user.
@@ -161,12 +146,11 @@ interface Likeable
     public function toggleDislikeBy($userId = null);
 
     /**
-     * Has the user already disliked likeable model.
+     * Delete likes related to the current record.
      *
-     * @param null|string|int $userId
-     * @return bool
+     * @return void
      */
-    public function isDislikedBy($userId = null): bool;
+    public function removeLikes();
 
     /**
      * Delete dislikes related to the current record.
@@ -174,4 +158,20 @@ interface Likeable
      * @return void
      */
     public function removeDislikes();
+
+    /**
+     * Has the user already liked likeable model.
+     *
+     * @param null|string|int $userId
+     * @return bool
+     */
+    public function isLikedBy($userId = null): bool;
+
+    /**
+     * Has the user already disliked likeable model.
+     *
+     * @param null|string|int $userId
+     * @return bool
+     */
+    public function isDislikedBy($userId = null): bool;
 }

--- a/contracts/Liker/Models/Liker.php
+++ b/contracts/Liker/Models/Liker.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Laravel Love.
+ *
+ * (c) Anton Komarev <a.komarev@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Contracts\Love\Liker\Models;
+
+use Cog\Contracts\Love\Likeable\Models\Likeable;
+
+/**
+ * Interface Liker.
+ *
+ * @package Cog\Contract\Likeable\Liker\Models
+ */
+interface Liker
+{
+    /**
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     */
+    public function like(Likeable $likeable);
+
+    /**
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     */
+    public function unlike(Likeable $likeable);
+
+    /**
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     */
+    public function dislike(Likeable $likeable);
+
+    /**
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     */
+    public function undislike(Likeable $likeable);
+
+    /**
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     */
+    public function toggleLike(Likeable $likeable);
+
+    /**
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     */
+    public function toggleDislike(Likeable $likeable);
+
+    /**
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return bool
+     */
+    public function hasLiked(Likeable $likeable): bool;
+
+    /**
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return bool
+     */
+    public function hasDisliked(Likeable $likeable): bool;
+}

--- a/contracts/Liker/Models/Liker.php
+++ b/contracts/Liker/Models/Liker.php
@@ -23,48 +23,64 @@ use Cog\Contracts\Love\Likeable\Models\Likeable;
 interface Liker
 {
     /**
+     * Add a like for the Likeable model.
+     *
      * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
      * @return void
      */
     public function like(Likeable $likeable);
 
     /**
-     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
-     * @return void
-     */
-    public function unlike(Likeable $likeable);
-
-    /**
+     * Add a dislike for the Likeable model.
+     *
      * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
      * @return void
      */
     public function dislike(Likeable $likeable);
 
     /**
+     * Remove a like from the Likeable model.
+     *
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     */
+    public function unlike(Likeable $likeable);
+
+    /**
+     * Remove a dislike from the Likeable model.
+     *
      * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
      * @return void
      */
     public function undislike(Likeable $likeable);
 
     /**
+     * Toggle like of the Likeable model.
+     *
      * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
      * @return void
      */
     public function toggleLike(Likeable $likeable);
 
     /**
+     * Toggle dislike of the Likeable model.
+     *
      * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
      * @return void
      */
     public function toggleDislike(Likeable $likeable);
 
     /**
+     * Determine if Liker has liked Likeable model.
+     *
      * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
      * @return bool
      */
     public function hasLiked(Likeable $likeable): bool;
 
     /**
+     * Determine if Liker has disliked Likeable model.
+     *
      * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
      * @return bool
      */

--- a/src/Likeable/Models/Traits/Likeable.php
+++ b/src/Likeable/Models/Traits/Likeable.php
@@ -115,7 +115,7 @@ trait Likeable
      *
      * @return int
      */
-    public function getLikesCountAttribute()
+    public function getLikesCountAttribute(): int
     {
         return $this->likesCounter ? $this->likesCounter->count : 0;
     }
@@ -125,7 +125,7 @@ trait Likeable
      *
      * @return int
      */
-    public function getDislikesCountAttribute()
+    public function getDislikesCountAttribute(): int
     {
         return $this->dislikesCounter ? $this->dislikesCounter->count : 0;
     }
@@ -135,7 +135,7 @@ trait Likeable
      *
      * @return bool
      */
-    public function getLikedAttribute()
+    public function getLikedAttribute(): bool
     {
         return $this->isLikedBy();
     }
@@ -145,7 +145,7 @@ trait Likeable
      *
      * @return bool
      */
-    public function getDislikedAttribute()
+    public function getDislikedAttribute(): bool
     {
         return $this->isDislikedBy();
     }
@@ -155,61 +155,9 @@ trait Likeable
      *
      * @return int
      */
-    public function getLikesDiffDislikesCountAttribute()
+    public function getLikesDiffDislikesCountAttribute(): int
     {
         return $this->likesCount - $this->dislikesCount;
-    }
-
-    /**
-     * Fetch records that are liked by a given user id.
-     *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param null|int $userId
-     * @return \Illuminate\Database\Eloquent\Builder
-     *
-     * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
-     */
-    public function scopeWhereLikedBy(Builder $query, $userId = null)
-    {
-        return $this->applyScopeWhereLikedBy($query, LikeType::LIKE, $userId);
-    }
-
-    /**
-     * Fetch records that are disliked by a given user id.
-     *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param null|int $userId
-     * @return \Illuminate\Database\Eloquent\Builder
-     *
-     * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
-     */
-    public function scopeWhereDislikedBy(Builder $query, $userId = null)
-    {
-        return $this->applyScopeWhereLikedBy($query, LikeType::DISLIKE, $userId);
-    }
-
-    /**
-     * Fetch records sorted by likes count.
-     *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param string $direction
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function scopeOrderByLikesCount(Builder $query, $direction = 'desc')
-    {
-        return $this->applyScopeOrderByLikesCount($query, LikeType::LIKE, $direction);
-    }
-
-    /**
-     * Fetch records sorted by likes count.
-     *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param string $direction
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function scopeOrderByDislikesCount(Builder $query, $direction = 'desc')
-    {
-        return $this->applyScopeOrderByLikesCount($query, LikeType::DISLIKE, $direction);
     }
 
     /**
@@ -226,53 +174,6 @@ trait Likeable
     }
 
     /**
-     * Remove a like from this record for the given user.
-     *
-     * @param null|int $userId If null will use currently logged in user.
-     * @return void
-     *
-     * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
-     */
-    public function unlikeBy($userId = null)
-    {
-        app(LikeableServiceContract::class)->removeLikeFrom($this, LikeType::LIKE, $userId);
-    }
-
-    /**
-     * Toggle like for model by the given user.
-     *
-     * @param mixed $userId If null will use currently logged in user.
-     * @return void
-     *
-     * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
-     */
-    public function toggleLikeBy($userId = null)
-    {
-        app(LikeableServiceContract::class)->toggleLikeOf($this, LikeType::LIKE, $userId);
-    }
-
-    /**
-     * Has the user already liked likeable model.
-     *
-     * @param null|int $userId
-     * @return bool
-     */
-    public function isLikedBy($userId = null): bool
-    {
-        return app(LikeableServiceContract::class)->isLiked($this, LikeType::LIKE, $userId);
-    }
-
-    /**
-     * Delete likes related to the current record.
-     *
-     * @return void
-     */
-    public function removeLikes()
-    {
-        app(LikeableServiceContract::class)->removeModelLikes($this, LikeType::LIKE);
-    }
-
-    /**
      * Add a dislike for model by the given user.
      *
      * @param mixed $userId If null will use currently logged in user.
@@ -283,6 +184,19 @@ trait Likeable
     public function dislikeBy($userId = null)
     {
         app(LikeableServiceContract::class)->addLikeTo($this, LikeType::DISLIKE, $userId);
+    }
+
+    /**
+     * Remove a like from this record for the given user.
+     *
+     * @param null|int $userId If null will use currently logged in user.
+     * @return void
+     *
+     * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
+     */
+    public function unlikeBy($userId = null)
+    {
+        app(LikeableServiceContract::class)->removeLikeFrom($this, LikeType::LIKE, $userId);
     }
 
     /**
@@ -299,6 +213,19 @@ trait Likeable
     }
 
     /**
+     * Toggle like for model by the given user.
+     *
+     * @param mixed $userId If null will use currently logged in user.
+     * @return void
+     *
+     * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
+     */
+    public function toggleLikeBy($userId = null)
+    {
+        app(LikeableServiceContract::class)->toggleLikeOf($this, LikeType::LIKE, $userId);
+    }
+
+    /**
      * Toggle dislike for model by the given user.
      *
      * @param mixed $userId If null will use currently logged in user.
@@ -309,6 +236,37 @@ trait Likeable
     public function toggleDislikeBy($userId = null)
     {
         app(LikeableServiceContract::class)->toggleLikeOf($this, LikeType::DISLIKE, $userId);
+    }
+
+    /**
+     * Delete likes related to the current record.
+     *
+     * @return void
+     */
+    public function removeLikes()
+    {
+        app(LikeableServiceContract::class)->removeModelLikes($this, LikeType::LIKE);
+    }
+
+    /**
+     * Delete dislikes related to the current record.
+     *
+     * @return void
+     */
+    public function removeDislikes()
+    {
+        app(LikeableServiceContract::class)->removeModelLikes($this, LikeType::DISLIKE);
+    }
+
+    /**
+     * Has the user already liked likeable model.
+     *
+     * @param null|int $userId
+     * @return bool
+     */
+    public function isLikedBy($userId = null): bool
+    {
+        return app(LikeableServiceContract::class)->isLiked($this, LikeType::LIKE, $userId);
     }
 
     /**
@@ -323,13 +281,55 @@ trait Likeable
     }
 
     /**
-     * Delete dislikes related to the current record.
+     * Fetch records that are liked by a given user id.
      *
-     * @return void
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param null|int $userId
+     * @return \Illuminate\Database\Eloquent\Builder
+     *
+     * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function removeDislikes()
+    public function scopeWhereLikedBy(Builder $query, $userId = null): Builder
     {
-        app(LikeableServiceContract::class)->removeModelLikes($this, LikeType::DISLIKE);
+        return $this->applyScopeWhereLikedBy($query, LikeType::LIKE, $userId);
+    }
+
+    /**
+     * Fetch records that are disliked by a given user id.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param null|int $userId
+     * @return \Illuminate\Database\Eloquent\Builder
+     *
+     * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
+     */
+    public function scopeWhereDislikedBy(Builder $query, $userId = null): Builder
+    {
+        return $this->applyScopeWhereLikedBy($query, LikeType::DISLIKE, $userId);
+    }
+
+    /**
+     * Fetch records sorted by likes count.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string $direction
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeOrderByLikesCount(Builder $query, string $direction = 'desc'): Builder
+    {
+        return $this->applyScopeOrderByLikesCount($query, LikeType::LIKE, $direction);
+    }
+
+    /**
+     * Fetch records sorted by likes count.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string $direction
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeOrderByDislikesCount(Builder $query, string $direction = 'desc'): Builder
+    {
+        return $this->applyScopeOrderByLikesCount($query, LikeType::DISLIKE, $direction);
     }
 
     /**
@@ -343,7 +343,7 @@ trait Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    private function applyScopeWhereLikedBy(Builder $query, $type, $userId)
+    private function applyScopeWhereLikedBy(Builder $query, string $type, $userId): Builder
     {
         $service = app(LikeableServiceContract::class);
         $userId = $service->getLikerUserId($userId);
@@ -364,7 +364,7 @@ trait Likeable
      * @param string $direction
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    private function applyScopeOrderByLikesCount(Builder $query, $likeType, $direction)
+    private function applyScopeOrderByLikesCount(Builder $query, string $likeType, string $direction): Builder
     {
         $likeable = $query->getModel();
         $typeId = app(LikeableServiceContract::class)->getLikeTypeId($likeType);

--- a/src/Likeable/Models/Traits/Likeable.php
+++ b/src/Likeable/Models/Traits/Likeable.php
@@ -137,7 +137,7 @@ trait Likeable
      */
     public function getLikedAttribute()
     {
-        return $this->liked();
+        return $this->isLikedBy();
     }
 
     /**
@@ -147,7 +147,7 @@ trait Likeable
      */
     public function getDislikedAttribute()
     {
-        return $this->disliked();
+        return $this->isDislikedBy();
     }
 
     /**
@@ -220,7 +220,7 @@ trait Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function like($userId = null)
+    public function likeBy($userId = null)
     {
         app(LikeableServiceContract::class)->addLikeTo($this, LikeType::LIKE, $userId);
     }
@@ -233,7 +233,7 @@ trait Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function unlike($userId = null)
+    public function unlikeBy($userId = null)
     {
         app(LikeableServiceContract::class)->removeLikeFrom($this, LikeType::LIKE, $userId);
     }
@@ -246,7 +246,7 @@ trait Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function likeToggle($userId = null)
+    public function toggleLikeBy($userId = null)
     {
         app(LikeableServiceContract::class)->toggleLikeOf($this, LikeType::LIKE, $userId);
     }
@@ -257,7 +257,7 @@ trait Likeable
      * @param null|int $userId
      * @return bool
      */
-    public function liked($userId = null): bool
+    public function isLikedBy($userId = null): bool
     {
         return app(LikeableServiceContract::class)->isLiked($this, LikeType::LIKE, $userId);
     }
@@ -280,7 +280,7 @@ trait Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function dislike($userId = null)
+    public function dislikeBy($userId = null)
     {
         app(LikeableServiceContract::class)->addLikeTo($this, LikeType::DISLIKE, $userId);
     }
@@ -293,7 +293,7 @@ trait Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function undislike($userId = null)
+    public function undislikeBy($userId = null)
     {
         app(LikeableServiceContract::class)->removeLikeFrom($this, LikeType::DISLIKE, $userId);
     }
@@ -306,7 +306,7 @@ trait Likeable
      *
      * @throws \Cog\Contracts\Love\Liker\Exceptions\InvalidLiker
      */
-    public function dislikeToggle($userId = null)
+    public function toggleDislikeBy($userId = null)
     {
         app(LikeableServiceContract::class)->toggleLikeOf($this, LikeType::DISLIKE, $userId);
     }
@@ -317,7 +317,7 @@ trait Likeable
      * @param null|int $userId
      * @return bool
      */
-    public function disliked($userId = null): bool
+    public function isDislikedBy($userId = null): bool
     {
         return app(LikeableServiceContract::class)->isLiked($this, LikeType::DISLIKE, $userId);
     }

--- a/src/Likeable/Services/LikeableService.php
+++ b/src/Likeable/Services/LikeableService.php
@@ -19,6 +19,7 @@ use Cog\Contracts\Love\Likeable\Models\Likeable as LikeableContract;
 use Cog\Contracts\Love\LikeCounter\Models\LikeCounter as LikeCounterContract;
 use Cog\Contracts\Love\Liker\Exceptions\InvalidLiker;
 use Cog\Contracts\Love\Likeable\Services\LikeableService as LikeableServiceContract;
+use Cog\Contracts\Love\Liker\Models\Liker as LikerContract;
 use Cog\Laravel\Love\Like\Enums\LikeType;
 use Illuminate\Support\Facades\DB;
 
@@ -133,6 +134,11 @@ class LikeableService implements LikeableServiceContract
      */
     public function isLiked(LikeableContract $likeable, $type, $userId): bool
     {
+        // TODO: (?) Use `$userId = $this->getLikerUserId($userId);`
+        if ($userId instanceof LikerContract) {
+            $userId = $userId->getKey();
+        }
+
         if (is_null($userId)) {
             $userId = $this->loggedInUserId();
         }
@@ -348,6 +354,10 @@ class LikeableService implements LikeableServiceContract
      */
     public function getLikerUserId($userId): int
     {
+        if ($userId instanceof LikerContract) {
+            return $userId->getKey();
+        }
+
         if (is_null($userId)) {
             $userId = $this->loggedInUserId();
         }

--- a/src/Liker/Models/Traits/Liker.php
+++ b/src/Liker/Models/Traits/Liker.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of Laravel Love.
+ *
+ * (c) Anton Komarev <a.komarev@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Laravel\Love\Liker\Models\Traits;
+
+use Cog\Contracts\Love\Likeable\Models\Likeable as LikeableContract;
+use Cog\Contracts\Love\Likeable\Services\LikeableService as LikeableServiceContract;
+use Cog\Laravel\Love\Like\Enums\LikeType;
+
+/**
+ * Trait Liker.
+ *
+ * @package Cog\Laravel\Love\Liker\Models\Traits
+ */
+trait Liker
+{
+    /**
+     * Add a like for model by the given user.
+     *
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     */
+    public function like(LikeableContract $likeable)
+    {
+        app(LikeableServiceContract::class)->addLikeTo($likeable, LikeType::LIKE, $this);
+    }
+
+    /**
+     * Remove a like from this record for the given user.
+     *
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     *
+     */
+    public function unlike(LikeableContract $likeable)
+    {
+        app(LikeableServiceContract::class)->removeLikeFrom($likeable, LikeType::LIKE, $this);
+    }
+
+    /**
+     * Toggle like for model by the given user.
+     *
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     *
+     */
+    public function toggleLike(LikeableContract $likeable)
+    {
+        app(LikeableServiceContract::class)->toggleLikeOf($likeable, LikeType::LIKE, $this);
+    }
+
+    /**
+     * Has the user already liked likeable model.
+     *
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return bool
+     */
+    public function hasLiked(LikeableContract $likeable): bool
+    {
+        return app(LikeableServiceContract::class)->isLiked($likeable, LikeType::LIKE, $this);
+    }
+
+    /**
+     * Add a dislike for model by the given user.
+     *
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     *
+     */
+    public function dislike(LikeableContract $likeable)
+    {
+        app(LikeableServiceContract::class)->addLikeTo($likeable, LikeType::DISLIKE, $this);
+    }
+
+    /**
+     * Remove a dislike from this record for the given user.
+     *
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     *
+     */
+    public function undislike(LikeableContract $likeable)
+    {
+        app(LikeableServiceContract::class)->removeLikeFrom($likeable, LikeType::DISLIKE, $this);
+    }
+
+    /**
+     * Toggle dislike for model by the given user.
+     *
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     *
+     */
+    public function toggleDislike(LikeableContract $likeable)
+    {
+        app(LikeableServiceContract::class)->toggleLikeOf($likeable, LikeType::DISLIKE, $this);
+    }
+
+    /**
+     * Has the user already disliked likeable model.
+     *
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return bool
+     */
+    public function hasDisliked(LikeableContract $likeable): bool
+    {
+        return app(LikeableServiceContract::class)->isLiked($likeable, LikeType::DISLIKE, $this);
+    }
+}

--- a/src/Liker/Models/Traits/Liker.php
+++ b/src/Liker/Models/Traits/Liker.php
@@ -25,7 +25,7 @@ use Cog\Laravel\Love\Like\Enums\LikeType;
 trait Liker
 {
     /**
-     * Add a like for model by the given user.
+     * Add a like for the Likeable model.
      *
      * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
      * @return void
@@ -36,11 +36,21 @@ trait Liker
     }
 
     /**
-     * Remove a like from this record for the given user.
+     * Add a dislike for the Likeable model.
      *
      * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
      * @return void
+     */
+    public function dislike(LikeableContract $likeable)
+    {
+        app(LikeableServiceContract::class)->addLikeTo($likeable, LikeType::DISLIKE, $this);
+    }
+
+    /**
+     * Remove a like from the Likeable model.
      *
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
      */
     public function unlike(LikeableContract $likeable)
     {
@@ -48,11 +58,21 @@ trait Liker
     }
 
     /**
-     * Toggle like for model by the given user.
+     * Remove a dislike from the Likeable model.
      *
      * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
      * @return void
+     */
+    public function undislike(LikeableContract $likeable)
+    {
+        app(LikeableServiceContract::class)->removeLikeFrom($likeable, LikeType::DISLIKE, $this);
+    }
+
+    /**
+     * Toggle like of the Likeable model.
      *
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
      */
     public function toggleLike(LikeableContract $likeable)
     {
@@ -60,7 +80,18 @@ trait Liker
     }
 
     /**
-     * Has the user already liked likeable model.
+     * Toggle dislike of the Likeable model.
+     *
+     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
+     * @return void
+     */
+    public function toggleDislike(LikeableContract $likeable)
+    {
+        app(LikeableServiceContract::class)->toggleLikeOf($likeable, LikeType::DISLIKE, $this);
+    }
+
+    /**
+     * Determine if Liker has liked Likeable model.
      *
      * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
      * @return bool
@@ -71,43 +102,7 @@ trait Liker
     }
 
     /**
-     * Add a dislike for model by the given user.
-     *
-     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
-     * @return void
-     *
-     */
-    public function dislike(LikeableContract $likeable)
-    {
-        app(LikeableServiceContract::class)->addLikeTo($likeable, LikeType::DISLIKE, $this);
-    }
-
-    /**
-     * Remove a dislike from this record for the given user.
-     *
-     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
-     * @return void
-     *
-     */
-    public function undislike(LikeableContract $likeable)
-    {
-        app(LikeableServiceContract::class)->removeLikeFrom($likeable, LikeType::DISLIKE, $this);
-    }
-
-    /**
-     * Toggle dislike for model by the given user.
-     *
-     * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
-     * @return void
-     *
-     */
-    public function toggleDislike(LikeableContract $likeable)
-    {
-        app(LikeableServiceContract::class)->toggleLikeOf($likeable, LikeType::DISLIKE, $this);
-    }
-
-    /**
-     * Has the user already disliked likeable model.
+     * Determine if Liker has disliked Likeable model.
      *
      * @param \Cog\Contracts\Love\Likeable\Models\Likeable $likeable
      * @return bool

--- a/tests/Stubs/Models/User.php
+++ b/tests/Stubs/Models/User.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Stubs\Models;
 
+use Cog\Contracts\Love\Liker\Models\Liker as LikerContract;
+use Cog\Laravel\Love\Liker\Models\Traits\Liker;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
 /**
@@ -20,8 +22,10 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
  *
  * @package Cog\Tests\Laravel\Love\Stubs\Models
  */
-class User extends Authenticatable
+class User extends Authenticatable implements LikerContract
 {
+    use Liker;
+
     /**
      * The table associated with the model.
      *

--- a/tests/Unit/Console/Commands/Recount.php
+++ b/tests/Unit/Console/Commands/Recount.php
@@ -48,15 +48,15 @@ class Recount extends TestCase
         $entity2 = factory(EntityWithMorphMap::class)->create();
         $article = factory(Article::class)->create();
 
-        $entity1->dislike(9);
-        $entity1->like(1);
-        $entity1->like(7);
-        $entity1->like(8);
-        $entity2->like(1);
-        $entity2->like(2);
-        $entity2->like(3);
-        $entity2->like(4);
-        $article->like(4);
+        $entity1->dislikeBy(9);
+        $entity1->likeBy(1);
+        $entity1->likeBy(7);
+        $entity1->likeBy(8);
+        $entity2->likeBy(1);
+        $entity2->likeBy(2);
+        $entity2->likeBy(3);
+        $entity2->likeBy(4);
+        $article->likeBy(4);
 
         LikeCounter::truncate();
 
@@ -84,14 +84,14 @@ class Recount extends TestCase
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
 
-        $entity1->dislike(9);
-        $entity1->like(1);
-        $entity1->like(7);
-        $entity1->like(8);
-        $entity2->like(1);
-        $entity2->like(2);
-        $entity2->like(3);
-        $entity2->like(4);
+        $entity1->dislikeBy(9);
+        $entity1->likeBy(1);
+        $entity1->likeBy(7);
+        $entity1->likeBy(8);
+        $entity2->likeBy(1);
+        $entity2->likeBy(2);
+        $entity2->likeBy(3);
+        $entity2->likeBy(4);
 
         LikeCounter::truncate();
 
@@ -119,14 +119,14 @@ class Recount extends TestCase
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
 
-        $entity1->dislike(9);
-        $entity1->like(1);
-        $entity1->like(7);
-        $entity1->like(8);
-        $entity2->like(1);
-        $entity2->like(2);
-        $entity2->like(3);
-        $entity2->like(4);
+        $entity1->dislikeBy(9);
+        $entity1->likeBy(1);
+        $entity1->likeBy(7);
+        $entity1->likeBy(8);
+        $entity2->likeBy(1);
+        $entity2->likeBy(2);
+        $entity2->likeBy(3);
+        $entity2->likeBy(4);
 
         LikeCounter::truncate();
 
@@ -154,14 +154,14 @@ class Recount extends TestCase
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
 
-        $entity1->dislike(9);
-        $entity1->like(1);
-        $entity1->like(7);
-        $entity1->like(8);
-        $entity2->like(1);
-        $entity2->like(2);
-        $entity2->like(3);
-        $entity2->like(4);
+        $entity1->dislikeBy(9);
+        $entity1->likeBy(1);
+        $entity1->likeBy(7);
+        $entity1->likeBy(8);
+        $entity2->likeBy(1);
+        $entity2->likeBy(2);
+        $entity2->likeBy(3);
+        $entity2->likeBy(4);
 
         LikeCounter::truncate();
 
@@ -192,15 +192,15 @@ class Recount extends TestCase
         $entity2 = factory(EntityWithMorphMap::class)->create();
         $article = factory(Article::class)->create();
 
-        $entity1->like(9);
-        $entity1->dislike(1);
-        $entity1->dislike(7);
-        $entity1->dislike(8);
-        $entity2->dislike(1);
-        $entity2->dislike(2);
-        $entity2->dislike(3);
-        $entity2->dislike(4);
-        $article->dislike(4);
+        $entity1->likeBy(9);
+        $entity1->dislikeBy(1);
+        $entity1->dislikeBy(7);
+        $entity1->dislikeBy(8);
+        $entity2->dislikeBy(1);
+        $entity2->dislikeBy(2);
+        $entity2->dislikeBy(3);
+        $entity2->dislikeBy(4);
+        $article->dislikeBy(4);
 
         LikeCounter::truncate();
 
@@ -228,14 +228,14 @@ class Recount extends TestCase
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
 
-        $entity1->like(9);
-        $entity1->dislike(1);
-        $entity1->dislike(7);
-        $entity1->dislike(8);
-        $entity2->dislike(1);
-        $entity2->dislike(2);
-        $entity2->dislike(3);
-        $entity2->dislike(4);
+        $entity1->likeBy(9);
+        $entity1->dislikeBy(1);
+        $entity1->dislikeBy(7);
+        $entity1->dislikeBy(8);
+        $entity2->dislikeBy(1);
+        $entity2->dislikeBy(2);
+        $entity2->dislikeBy(3);
+        $entity2->dislikeBy(4);
 
         LikeCounter::truncate();
 
@@ -263,14 +263,14 @@ class Recount extends TestCase
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
 
-        $entity1->like(9);
-        $entity1->dislike(1);
-        $entity1->dislike(7);
-        $entity1->dislike(8);
-        $entity2->dislike(1);
-        $entity2->dislike(2);
-        $entity2->dislike(3);
-        $entity2->dislike(4);
+        $entity1->likeBy(9);
+        $entity1->dislikeBy(1);
+        $entity1->dislikeBy(7);
+        $entity1->dislikeBy(8);
+        $entity2->dislikeBy(1);
+        $entity2->dislikeBy(2);
+        $entity2->dislikeBy(3);
+        $entity2->dislikeBy(4);
 
         LikeCounter::truncate();
 
@@ -298,14 +298,14 @@ class Recount extends TestCase
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
 
-        $entity1->like(9);
-        $entity1->dislike(1);
-        $entity1->dislike(7);
-        $entity1->dislike(8);
-        $entity2->dislike(1);
-        $entity2->dislike(2);
-        $entity2->dislike(3);
-        $entity2->dislike(4);
+        $entity1->likeBy(9);
+        $entity1->dislikeBy(1);
+        $entity1->dislikeBy(7);
+        $entity1->dislikeBy(8);
+        $entity2->dislikeBy(1);
+        $entity2->dislikeBy(2);
+        $entity2->dislikeBy(3);
+        $entity2->dislikeBy(4);
 
         LikeCounter::truncate();
 
@@ -336,14 +336,14 @@ class Recount extends TestCase
         $entity2 = factory(EntityWithMorphMap::class)->create();
         $article = factory(Article::class)->create();
 
-        $entity1->like(9);
-        $entity1->like(7);
-        $entity1->dislike(8);
-        $entity2->like(1);
-        $entity2->like(2);
-        $entity2->dislike(3);
-        $entity2->dislike(4);
-        $article->dislike(4);
+        $entity1->likeBy(9);
+        $entity1->likeBy(7);
+        $entity1->dislikeBy(8);
+        $entity2->likeBy(1);
+        $entity2->likeBy(2);
+        $entity2->dislikeBy(3);
+        $entity2->dislikeBy(4);
+        $article->dislikeBy(4);
 
         LikeCounter::truncate();
 
@@ -371,13 +371,13 @@ class Recount extends TestCase
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
 
-        $entity1->like(9);
-        $entity1->like(7);
-        $entity1->dislike(8);
-        $entity2->like(1);
-        $entity2->like(2);
-        $entity2->dislike(3);
-        $entity2->dislike(4);
+        $entity1->likeBy(9);
+        $entity1->likeBy(7);
+        $entity1->dislikeBy(8);
+        $entity2->likeBy(1);
+        $entity2->likeBy(2);
+        $entity2->dislikeBy(3);
+        $entity2->dislikeBy(4);
 
         LikeCounter::truncate();
 
@@ -405,13 +405,13 @@ class Recount extends TestCase
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
 
-        $entity1->like(1);
-        $entity1->like(7);
-        $entity1->dislike(8);
-        $entity2->like(1);
-        $entity2->like(2);
-        $entity2->dislike(3);
-        $entity2->dislike(4);
+        $entity1->likeBy(1);
+        $entity1->likeBy(7);
+        $entity1->dislikeBy(8);
+        $entity2->likeBy(1);
+        $entity2->likeBy(2);
+        $entity2->dislikeBy(3);
+        $entity2->dislikeBy(4);
 
         LikeCounter::truncate();
 
@@ -439,13 +439,13 @@ class Recount extends TestCase
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
 
-        $entity1->like(1);
-        $entity1->like(7);
-        $entity1->dislike(8);
-        $entity2->like(1);
-        $entity2->like(2);
-        $entity2->dislike(3);
-        $entity2->dislike(4);
+        $entity1->likeBy(1);
+        $entity1->likeBy(7);
+        $entity1->dislikeBy(8);
+        $entity2->likeBy(1);
+        $entity2->likeBy(2);
+        $entity2->dislikeBy(3);
+        $entity2->dislikeBy(4);
 
         LikeCounter::truncate();
 

--- a/tests/Unit/Like/Models/LikeTest.php
+++ b/tests/Unit/Like/Models/LikeTest.php
@@ -49,7 +49,7 @@ class LikeTest extends TestCase
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->like(1);
+        $entity->likeBy(1);
 
         $this->assertInstanceOf(Entity::class, Like::first()->likeable);
     }

--- a/tests/Unit/Like/Observers/LikeObserverTest.php
+++ b/tests/Unit/Like/Observers/LikeObserverTest.php
@@ -130,7 +130,7 @@ class LikeObserverTest extends TestCase
     public function it_decrement_likeable_likes_count_on_like_model_deleted()
     {
         $likeable = factory(Entity::class)->create();
-        $likeable->like(1);
+        $likeable->likeBy(1);
         $likeableService = Mockery::mock(LikeableService::class);
         $like = Mockery::mock(LikeContract::class);
         $like->type_id = LikeType::LIKE;
@@ -148,7 +148,7 @@ class LikeObserverTest extends TestCase
     public function it_decrement_likeable_dislikes_count_on_like_model_deleted()
     {
         $likeable = factory(Entity::class)->create();
-        $likeable->dislike(1);
+        $likeable->dislikeBy(1);
         $likeableService = Mockery::mock(LikeableService::class);
         $like = Mockery::mock(LikeContract::class);
         $like->type_id = LikeType::DISLIKE;

--- a/tests/Unit/LikeCounter/Models/LikeCounterTest.php
+++ b/tests/Unit/LikeCounter/Models/LikeCounterTest.php
@@ -59,7 +59,7 @@ class LikeCounterTest extends TestCase
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->like(1);
+        $entity->likeBy(1);
 
         $this->assertInstanceOf(Entity::class, LikeCounter::first()->likeable);
     }

--- a/tests/Unit/Likeable/Events/LikeableWasDislikedTest.php
+++ b/tests/Unit/Likeable/Events/LikeableWasDislikedTest.php
@@ -33,6 +33,6 @@ class LikeableWasDislikedTest extends TestCase
         $this->expectsEvents(LikeableWasDisliked::class);
 
         $entity = factory(Entity::class)->create();
-        $entity->dislike(1);
+        $entity->dislikeBy(1);
     }
 }

--- a/tests/Unit/Likeable/Events/LikeableWasLikedTest.php
+++ b/tests/Unit/Likeable/Events/LikeableWasLikedTest.php
@@ -33,6 +33,6 @@ class LikeableWasLikedTest extends TestCase
         $this->expectsEvents(LikeableWasLiked::class);
 
         $entity = factory(Entity::class)->create();
-        $entity->like(1);
+        $entity->likeBy(1);
     }
 }

--- a/tests/Unit/Likeable/Events/LikeableWasUndislikedTest.php
+++ b/tests/Unit/Likeable/Events/LikeableWasUndislikedTest.php
@@ -33,8 +33,8 @@ class LikeableWasUndislikedTest extends TestCase
         $this->expectsEvents(LikeableWasUndisliked::class);
 
         $entity = factory(Entity::class)->create();
-        $entity->dislike(1);
+        $entity->dislikeBy(1);
 
-        $entity->undislike(1);
+        $entity->undislikeBy(1);
     }
 }

--- a/tests/Unit/Likeable/Events/LikeableWasUnlikedTest.php
+++ b/tests/Unit/Likeable/Events/LikeableWasUnlikedTest.php
@@ -33,8 +33,8 @@ class LikeableWasUnlikedTest extends TestCase
         $this->expectsEvents(LikeableWasUnliked::class);
 
         $entity = factory(Entity::class)->create();
-        $entity->like(1);
+        $entity->likeBy(1);
 
-        $entity->unlike(1);
+        $entity->unlikeBy(1);
     }
 }

--- a/tests/Unit/Likeable/Models/Traits/LikeableTest.php
+++ b/tests/Unit/Likeable/Models/Traits/LikeableTest.php
@@ -39,7 +39,7 @@ class LikeableTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
 
-        $entity->like();
+        $entity->likeBy();
 
         $this->assertEquals(1, $entity->likesCount);
         $this->assertEquals($user->id, $entity->likes->first()->user_id);
@@ -54,7 +54,7 @@ class LikeableTest extends TestCase
         $user2 = factory(User::class)->create();
         $this->actingAs($user1);
 
-        $entity->like($user2->id);
+        $entity->likeBy($user2->id);
 
         $this->assertEquals(1, $entity->likesCount);
         $this->assertEquals($user2->id, $entity->likes->first()->user_id);
@@ -65,10 +65,10 @@ class LikeableTest extends TestCase
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->like(1);
-        $entity->like(2);
-        $entity->like(3);
-        $entity->like(4);
+        $entity->likeBy(1);
+        $entity->likeBy(2);
+        $entity->likeBy(3);
+        $entity->likeBy(4);
 
         $this->assertEquals(4, $entity->likesCount);
     }
@@ -78,19 +78,19 @@ class LikeableTest extends TestCase
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->like(1);
-        $entity->like(1);
+        $entity->likeBy(1);
+        $entity->likeBy(1);
 
         $this->assertEquals(1, $entity->likesCount);
     }
 
     /** @test */
-    public function it_can_unlike()
+    public function it_can_unlikeBy()
     {
         $entity = factory(Entity::class)->create();
-        $entity->like(1);
+        $entity->likeBy(1);
 
-        $entity->unlike(1);
+        $entity->unlikeBy(1);
 
         $this->assertEquals(0, $entity->likesCount);
     }
@@ -99,9 +99,9 @@ class LikeableTest extends TestCase
     public function it_cannot_unlike_by_user_if_not_liked()
     {
         $entity = factory(Entity::class)->create();
-        $entity->like(1);
+        $entity->likeBy(1);
 
-        $entity->unlike(2);
+        $entity->unlikeBy(2);
 
         $this->assertEquals(1, $entity->likesCount);
     }
@@ -114,7 +114,7 @@ class LikeableTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
 
-        $entity->likeToggle();
+        $entity->toggleLikeBy();
 
         $this->assertEquals(1, $entity->likesCount);
         $this->assertEquals($user->id, $entity->likes->first()->user_id);
@@ -127,9 +127,9 @@ class LikeableTest extends TestCase
 
         $user = factory(User::class)->create();
         $this->actingAs($user);
-        $entity->like();
+        $entity->likeBy();
 
-        $entity->likeToggle();
+        $entity->toggleLikeBy();
 
         $this->assertEquals(0, $entity->likesCount);
     }
@@ -139,7 +139,7 @@ class LikeableTest extends TestCase
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->likeToggle(1);
+        $entity->toggleLikeBy(1);
         $this->assertEquals(1, $entity->likesCount);
     }
 
@@ -147,9 +147,9 @@ class LikeableTest extends TestCase
     public function it_can_remove_like_with_toggle_by_concrete_user()
     {
         $entity = factory(Entity::class)->create();
-        $entity->like(1);
+        $entity->likeBy(1);
 
-        $entity->likeToggle(1);
+        $entity->toggleLikeBy(1);
         $this->assertEquals(0, $entity->likesCount);
     }
 
@@ -159,19 +159,19 @@ class LikeableTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
         $entity = factory(Entity::class)->create();
-        $entity->like();
+        $entity->likeBy();
 
-        $this->assertTrue($entity->liked());
+        $this->assertTrue($entity->isLikedBy());
     }
 
     /** @test */
     public function it_can_check_if_entity_liked_by_concrete_user()
     {
         $entity = factory(Entity::class)->create();
-        $entity->like(1);
+        $entity->likeBy(1);
 
-        $this->assertTrue($entity->liked(1));
-        $this->assertFalse($entity->liked(2));
+        $this->assertTrue($entity->isLikedBy(1));
+        $this->assertFalse($entity->isLikedBy(2));
     }
 
     /** @test */
@@ -180,7 +180,7 @@ class LikeableTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
         $entity = factory(Entity::class)->create();
-        $entity->like();
+        $entity->likeBy();
 
         $this->assertTrue($entity->liked);
     }
@@ -190,9 +190,9 @@ class LikeableTest extends TestCase
     {
         $user = factory(User::class)->create();
         $this->actingAs($user);
-        factory(Entity::class)->create()->like($user->id);
-        factory(Entity::class)->create()->like($user->id);
-        factory(Entity::class)->create()->like($user->id);
+        factory(Entity::class)->create()->likeBy($user->id);
+        factory(Entity::class)->create()->likeBy($user->id);
+        factory(Entity::class)->create()->likeBy($user->id);
 
         $likedEntities = Entity::whereLikedBy()->get();
 
@@ -202,9 +202,9 @@ class LikeableTest extends TestCase
     /** @test */
     public function it_can_get_where_liked_by_concrete_user()
     {
-        factory(Entity::class)->create()->like(1);
-        factory(Entity::class)->create()->like(1);
-        factory(Entity::class)->create()->like(1);
+        factory(Entity::class)->create()->likeBy(1);
+        factory(Entity::class)->create()->likeBy(1);
+        factory(Entity::class)->create()->likeBy(1);
 
         $likedEntities = Entity::whereLikedBy(1)->get();
         $shouldBeEmpty = Entity::whereLikedBy(2)->get();
@@ -223,7 +223,7 @@ class LikeableTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
 
-        $entity->dislike();
+        $entity->dislikeBy();
 
         $this->assertEquals(1, $entity->dislikesCount);
         $this->assertEquals($user->id, $entity->dislikes->first()->user_id);
@@ -238,7 +238,7 @@ class LikeableTest extends TestCase
         $user2 = factory(User::class)->create();
         $this->actingAs($user1);
 
-        $entity->dislike($user2->id);
+        $entity->dislikeBy($user2->id);
 
         $this->assertEquals(1, $entity->dislikesCount);
         $this->assertEquals($user2->id, $entity->dislikes->first()->user_id);
@@ -249,10 +249,10 @@ class LikeableTest extends TestCase
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->dislike(1);
-        $entity->dislike(2);
-        $entity->dislike(3);
-        $entity->dislike(4);
+        $entity->dislikeBy(1);
+        $entity->dislikeBy(2);
+        $entity->dislikeBy(3);
+        $entity->dislikeBy(4);
 
         $this->assertEquals(4, $entity->dislikesCount);
     }
@@ -262,19 +262,19 @@ class LikeableTest extends TestCase
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->dislike(1);
-        $entity->dislike(1);
+        $entity->dislikeBy(1);
+        $entity->dislikeBy(1);
 
         $this->assertEquals(1, $entity->dislikesCount);
     }
 
     /** @test */
-    public function it_can_undislike()
+    public function it_can_undislikeBy()
     {
         $entity = factory(Entity::class)->create();
-        $entity->dislike(1);
+        $entity->dislikeBy(1);
 
-        $entity->undislike(1);
+        $entity->undislikeBy(1);
 
         $this->assertEquals(0, $entity->dislikesCount);
     }
@@ -283,9 +283,9 @@ class LikeableTest extends TestCase
     public function it_cannot_undislike_by_user_if_not_disliked()
     {
         $entity = factory(Entity::class)->create();
-        $entity->dislike(1);
+        $entity->dislikeBy(1);
 
-        $entity->undislike(2);
+        $entity->undislikeBy(2);
 
         $this->assertEquals(1, $entity->dislikesCount);
     }
@@ -298,7 +298,7 @@ class LikeableTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
 
-        $entity->dislikeToggle();
+        $entity->toggleDislikeBy();
 
         $this->assertEquals(1, $entity->dislikesCount);
         $this->assertEquals($user->id, $entity->dislikes->first()->user_id);
@@ -311,9 +311,9 @@ class LikeableTest extends TestCase
 
         $user = factory(User::class)->create();
         $this->actingAs($user);
-        $entity->dislike();
+        $entity->dislikeBy();
 
-        $entity->dislikeToggle();
+        $entity->toggleDislikeBy();
 
         $this->assertEquals(0, $entity->dislikesCount);
     }
@@ -323,7 +323,7 @@ class LikeableTest extends TestCase
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->dislikeToggle(1);
+        $entity->toggleDislikeBy(1);
         $this->assertEquals(1, $entity->dislikesCount);
     }
 
@@ -331,9 +331,9 @@ class LikeableTest extends TestCase
     public function it_can_remove_dislike_with_toggle_by_concrete_user()
     {
         $entity = factory(Entity::class)->create();
-        $entity->dislike(1);
+        $entity->dislikeBy(1);
 
-        $entity->dislikeToggle(1);
+        $entity->toggleDislikeBy(1);
         $this->assertEquals(0, $entity->dislikesCount);
     }
 
@@ -343,19 +343,19 @@ class LikeableTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
         $entity = factory(Entity::class)->create();
-        $entity->dislike();
+        $entity->dislikeBy();
 
-        $this->assertTrue($entity->disliked());
+        $this->assertTrue($entity->isDislikedBy());
     }
 
     /** @test */
     public function it_can_check_if_entity_disliked_by_concrete_user()
     {
         $entity = factory(Entity::class)->create();
-        $entity->dislike(1);
+        $entity->dislikeBy(1);
 
-        $this->assertTrue($entity->disliked(1));
-        $this->assertFalse($entity->disliked(2));
+        $this->assertTrue($entity->isDislikedBy(1));
+        $this->assertFalse($entity->isDislikedBy(2));
     }
 
     /** @test */
@@ -364,7 +364,7 @@ class LikeableTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
         $entity = factory(Entity::class)->create();
-        $entity->dislike();
+        $entity->dislikeBy();
 
         $this->assertTrue($entity->disliked);
     }
@@ -374,9 +374,9 @@ class LikeableTest extends TestCase
     {
         $user = factory(User::class)->create();
         $this->actingAs($user);
-        factory(Entity::class)->create()->dislike($user->id);
-        factory(Entity::class)->create()->dislike($user->id);
-        factory(Entity::class)->create()->dislike($user->id);
+        factory(Entity::class)->create()->dislikeBy($user->id);
+        factory(Entity::class)->create()->dislikeBy($user->id);
+        factory(Entity::class)->create()->dislikeBy($user->id);
 
         $dislikedEntities = Entity::whereDislikedBy()->get();
 
@@ -386,9 +386,9 @@ class LikeableTest extends TestCase
     /** @test */
     public function it_can_get_where_disliked_by_concrete_user()
     {
-        factory(Entity::class)->create()->dislike(1);
-        factory(Entity::class)->create()->dislike(1);
-        factory(Entity::class)->create()->dislike(1);
+        factory(Entity::class)->create()->dislikeBy(1);
+        factory(Entity::class)->create()->dislikeBy(1);
+        factory(Entity::class)->create()->dislikeBy(1);
 
         $dislikedEntities = Entity::whereDislikedBy(1)->get();
         $shouldBeEmpty = Entity::whereDislikedBy(2)->get();
@@ -404,7 +404,7 @@ class LikeableTest extends TestCase
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->like(1);
+        $entity->likeBy(1);
 
         $this->assertInstanceOf(LikeContract::class, $entity->likes->first());
         $this->assertCount(1, $entity->likes);
@@ -415,7 +415,7 @@ class LikeableTest extends TestCase
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->dislike(1);
+        $entity->dislikeBy(1);
 
         $this->assertInstanceOf(LikeContract::class, $entity->dislikes->first());
         $this->assertCount(1, $entity->dislikes);
@@ -429,14 +429,14 @@ class LikeableTest extends TestCase
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
         $entity3 = factory(Entity::class)->create();
-        $entity1->like($user->id);
-        $entity3->like($user->id);
+        $entity1->likeBy($user->id);
+        $entity3->likeBy($user->id);
 
         DB::enableQueryLog();
         $entities = Entity::with('likes')->get();
         $entitiesIsLiked = [];
         foreach ($entities as $entity) {
-            $entitiesIsLiked[] = $entity->liked();
+            $entitiesIsLiked[] = $entity->isLikedBy();
         }
         $queryLog = DB::getQueryLog();
 
@@ -454,14 +454,14 @@ class LikeableTest extends TestCase
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
         $entity3 = factory(Entity::class)->create();
-        $entity1->like($user->id);
-        $entity3->like($user->id);
+        $entity1->likeBy($user->id);
+        $entity3->likeBy($user->id);
 
         DB::enableQueryLog();
         $entities = Entity::with('likesAndDislikes')->get();
         $entitiesIsLiked = [];
         foreach ($entities as $entity) {
-            $entitiesIsLiked[] = $entity->liked();
+            $entitiesIsLiked[] = $entity->isLikedBy();
         }
         $queryLog = DB::getQueryLog();
 
@@ -479,14 +479,14 @@ class LikeableTest extends TestCase
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
         $entity3 = factory(Entity::class)->create();
-        $entity1->like($user->id);
-        $entity3->like($user->id);
+        $entity1->likeBy($user->id);
+        $entity3->likeBy($user->id);
 
         DB::enableQueryLog();
         $entities = Entity::with('dislikes')->get();
         $entitiesIsLiked = [];
         foreach ($entities as $entity) {
-            $entitiesIsLiked[] = $entity->liked();
+            $entitiesIsLiked[] = $entity->isLikedBy();
         }
         $queryLog = DB::getQueryLog();
 
@@ -504,14 +504,14 @@ class LikeableTest extends TestCase
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
         $entity3 = factory(Entity::class)->create();
-        $entity1->dislike($user->id);
-        $entity3->dislike($user->id);
+        $entity1->dislikeBy($user->id);
+        $entity3->dislikeBy($user->id);
 
         DB::enableQueryLog();
         $entities = Entity::with('dislikes')->get();
         $entitiesIsDisliked = [];
         foreach ($entities as $entity) {
-            $entitiesIsDisliked[] = $entity->disliked();
+            $entitiesIsDisliked[] = $entity->isDislikedBy();
         }
         $queryLog = DB::getQueryLog();
 
@@ -529,14 +529,14 @@ class LikeableTest extends TestCase
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
         $entity3 = factory(Entity::class)->create();
-        $entity1->dislike($user->id);
-        $entity3->dislike($user->id);
+        $entity1->dislikeBy($user->id);
+        $entity3->dislikeBy($user->id);
 
         DB::enableQueryLog();
         $entities = Entity::with('likesAndDislikes')->get();
         $entitiesIsDisliked = [];
         foreach ($entities as $entity) {
-            $entitiesIsDisliked[] = $entity->disliked();
+            $entitiesIsDisliked[] = $entity->isDislikedBy();
         }
         $queryLog = DB::getQueryLog();
 
@@ -554,14 +554,14 @@ class LikeableTest extends TestCase
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
         $entity3 = factory(Entity::class)->create();
-        $entity1->dislike($user->id);
-        $entity3->dislike($user->id);
+        $entity1->dislikeBy($user->id);
+        $entity3->dislikeBy($user->id);
 
         DB::enableQueryLog();
         $entities = Entity::with('likes')->get();
         $entitiesIsDisliked = [];
         foreach ($entities as $entity) {
-            $entitiesIsDisliked[] = $entity->disliked();
+            $entitiesIsDisliked[] = $entity->isDislikedBy();
         }
         $queryLog = DB::getQueryLog();
 
@@ -576,8 +576,8 @@ class LikeableTest extends TestCase
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->like(1);
-        $entity->dislike(2);
+        $entity->likeBy(1);
+        $entity->dislikeBy(2);
 
         $this->assertInstanceOf(LikeContract::class, $entity->likesAndDislikes->first());
         $this->assertCount(2, $entity->likesAndDislikes);
@@ -588,9 +588,9 @@ class LikeableTest extends TestCase
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->like(1);
-        $entity->dislike(2);
-        $entity->dislike(3);
+        $entity->likeBy(1);
+        $entity->dislikeBy(2);
+        $entity->dislikeBy(3);
 
         $this->assertEquals(-1, $entity->likesDiffDislikesCount);
     }
@@ -603,18 +603,18 @@ class LikeableTest extends TestCase
         $entityC = factory(Entity::class)->create();
         $entityD = factory(Entity::class)->create();
         for ($i = 0; $i < 3; $i++) {
-            $entityA->like(mt_rand(1, 9999999));
+            $entityA->likeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 1; $i++) {
-            $entityB->like(mt_rand(1, 9999999));
-            $entityB->dislike(mt_rand(1, 9999999));
+            $entityB->likeBy(mt_rand(1, 9999999));
+            $entityB->dislikeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 5; $i++) {
-            $entityC->like(mt_rand(1, 9999999));
+            $entityC->likeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 10; $i++) {
-            $entityD->like(mt_rand(1, 9999999));
-            $entityD->dislike(mt_rand(1, 9999999));
+            $entityD->likeBy(mt_rand(1, 9999999));
+            $entityD->dislikeBy(mt_rand(1, 9999999));
         }
 
         $sortedEntities = Entity::orderByLikesCount('desc')->get();
@@ -635,18 +635,18 @@ class LikeableTest extends TestCase
         $entityC = factory(Entity::class)->create();
         $entityD = factory(Entity::class)->create();
         for ($i = 0; $i < 3; $i++) {
-            $entityA->like(mt_rand(1, 9999999));
+            $entityA->likeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 1; $i++) {
-            $entityB->like(mt_rand(1, 9999999));
-            $entityB->dislike(mt_rand(1, 9999999));
+            $entityB->likeBy(mt_rand(1, 9999999));
+            $entityB->dislikeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 5; $i++) {
-            $entityC->like(mt_rand(1, 9999999));
+            $entityC->likeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 10; $i++) {
-            $entityD->like(mt_rand(1, 9999999));
-            $entityD->dislike(mt_rand(1, 9999999));
+            $entityD->likeBy(mt_rand(1, 9999999));
+            $entityD->dislikeBy(mt_rand(1, 9999999));
         }
 
         $sortedEntities = Entity::orderByLikesCount('asc')->get();
@@ -667,11 +667,11 @@ class LikeableTest extends TestCase
         $entityC = factory(Entity::class)->create();
         $entityD = factory(Entity::class)->create();
         for ($i = 0; $i < 3; $i++) {
-            $entityA->like(mt_rand(1, 9999999));
+            $entityA->likeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 10; $i++) {
-            $entityD->like(mt_rand(1, 9999999));
-            $entityD->dislike(mt_rand(1, 9999999));
+            $entityD->likeBy(mt_rand(1, 9999999));
+            $entityD->dislikeBy(mt_rand(1, 9999999));
         }
 
         $sortedEntities = Entity::orderByLikesCount('desc')->get();
@@ -692,18 +692,18 @@ class LikeableTest extends TestCase
         $entityC = factory(Entity::class)->create();
         $entityD = factory(Entity::class)->create();
         for ($i = 0; $i < 3; $i++) {
-            $entityA->dislike(mt_rand(1, 9999999));
+            $entityA->dislikeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 1; $i++) {
-            $entityB->dislike(mt_rand(1, 9999999));
-            $entityB->like(mt_rand(1, 9999999));
+            $entityB->dislikeBy(mt_rand(1, 9999999));
+            $entityB->likeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 5; $i++) {
-            $entityC->dislike(mt_rand(1, 9999999));
+            $entityC->dislikeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 10; $i++) {
-            $entityD->dislike(mt_rand(1, 9999999));
-            $entityD->like(mt_rand(1, 9999999));
+            $entityD->dislikeBy(mt_rand(1, 9999999));
+            $entityD->likeBy(mt_rand(1, 9999999));
         }
 
         $sortedEntities = Entity::orderByDislikesCount('desc')->get();
@@ -724,18 +724,18 @@ class LikeableTest extends TestCase
         $entityC = factory(Entity::class)->create();
         $entityD = factory(Entity::class)->create();
         for ($i = 0; $i < 3; $i++) {
-            $entityA->dislike(mt_rand(1, 9999999));
+            $entityA->dislikeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 1; $i++) {
-            $entityB->dislike(mt_rand(1, 9999999));
+            $entityB->dislikeBy(mt_rand(1, 9999999));
             $entityB->likes(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 5; $i++) {
-            $entityC->dislike(mt_rand(1, 9999999));
-            $entityC->like(mt_rand(1, 9999999));
+            $entityC->dislikeBy(mt_rand(1, 9999999));
+            $entityC->likeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 10; $i++) {
-            $entityD->dislike(mt_rand(1, 9999999));
+            $entityD->dislikeBy(mt_rand(1, 9999999));
         }
 
         $sortedEntities = Entity::orderByDislikesCount('asc')->get();
@@ -756,11 +756,11 @@ class LikeableTest extends TestCase
         $entityC = factory(Entity::class)->create();
         $entityD = factory(Entity::class)->create();
         for ($i = 0; $i < 3; $i++) {
-            $entityA->dislike(mt_rand(1, 9999999));
+            $entityA->dislikeBy(mt_rand(1, 9999999));
         }
         for ($i = 0; $i < 10; $i++) {
-            $entityD->like(mt_rand(1, 9999999));
-            $entityD->dislike(mt_rand(1, 9999999));
+            $entityD->likeBy(mt_rand(1, 9999999));
+            $entityD->dislikeBy(mt_rand(1, 9999999));
         }
 
         $sortedEntities = Entity::orderByDislikesCount('desc')->get();
@@ -780,9 +780,9 @@ class LikeableTest extends TestCase
         $user1 = factory(User::class)->create();
         $user2 = factory(User::class)->create();
         $user3 = factory(User::class)->create();
-        $entity->like($user1->id);
-        $entity->dislike($user2->id);
-        $entity->like($user3->id);
+        $entity->likeBy($user1->id);
+        $entity->dislikeBy($user2->id);
+        $entity->likeBy($user3->id);
 
         $likers = $entity->collectLikers();
 
@@ -797,9 +797,9 @@ class LikeableTest extends TestCase
         $user1 = factory(User::class)->create();
         $user2 = factory(User::class)->create();
         $user3 = factory(User::class)->create();
-        $entity->dislike($user1->id);
-        $entity->like($user2->id);
-        $entity->dislike($user3->id);
+        $entity->dislikeBy($user1->id);
+        $entity->likeBy($user2->id);
+        $entity->dislikeBy($user3->id);
 
         $dislikers = $entity->collectDislikers();
 

--- a/tests/Unit/Likeable/Observers/LikeableObserverTest.php
+++ b/tests/Unit/Likeable/Observers/LikeableObserverTest.php
@@ -35,7 +35,7 @@ class LikeableObserverTest extends TestCase
     public function it_remove_likes_on_likeable_delete()
     {
         $likeable = factory(Entity::class)->create();
-        $likeable->like(1);
+        $likeable->likeBy(1);
         $likeableService = Mockery::mock(LikeableServiceContract::class);
         $likeableService->shouldReceive('removeModelLikes');
         $likeableObserver = new LikeableObserver();
@@ -49,7 +49,7 @@ class LikeableObserverTest extends TestCase
     public function it_can_omit_remove_likes_on_likeable_delete()
     {
         $likeable = factory(Entity::class)->create();
-        $likeable->like(1);
+        $likeable->likeBy(1);
         $likeable->removeLikesOnDelete = false;
         $likeableService = Mockery::mock(LikeableServiceContract::class);
         $likeableService->shouldNotHaveReceived('removeModelLikes');
@@ -66,13 +66,13 @@ class LikeableObserverTest extends TestCase
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
 
-        $entity1->like(1);
-        $entity1->like(7);
-        $entity1->like(8);
-        $entity2->like(1);
-        $entity2->like(2);
-        $entity2->like(3);
-        $entity2->like(4);
+        $entity1->likeBy(1);
+        $entity1->likeBy(7);
+        $entity1->likeBy(8);
+        $entity2->likeBy(1);
+        $entity2->likeBy(2);
+        $entity2->likeBy(3);
+        $entity2->likeBy(4);
 
         $entity1Likes = $entity1->likes;
 

--- a/tests/Unit/Likeable/Services/LikeableServiceTest.php
+++ b/tests/Unit/Likeable/Services/LikeableServiceTest.php
@@ -45,8 +45,8 @@ class LikeableServiceTest extends TestCase
     {
         $service = $this->app->make(LikeableServiceContract::class);
         $entity = factory(Entity::class)->create();
-        $entity->like(1);
-        $entity->like(2);
+        $entity->likeBy(1);
+        $entity->likeBy(2);
 
         $service->decrementLikesCount($entity);
         $service->decrementLikesCount($entity);
@@ -84,9 +84,9 @@ class LikeableServiceTest extends TestCase
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
         $article = factory(Article::class)->create();
-        $entity1->like(1);
-        $entity2->like(2);
-        $article->like(1);
+        $entity1->likeBy(1);
+        $entity2->likeBy(2);
+        $article->likeBy(1);
 
         $service->removeLikeCountersOfType(Entity::class, 'LIKE');
 
@@ -102,9 +102,9 @@ class LikeableServiceTest extends TestCase
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
         $article = factory(Article::class)->create();
-        $entity1->like(1);
-        $entity2->like(2);
-        $article->like(1);
+        $entity1->likeBy(1);
+        $entity2->likeBy(2);
+        $article->likeBy(1);
 
         $service->removeLikeCountersOfType('entity-with-morph-map', 'LIKE');
 
@@ -120,9 +120,9 @@ class LikeableServiceTest extends TestCase
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
         $article = factory(Article::class)->create();
-        $entity1->like(1);
-        $entity2->like(2);
-        $article->like(1);
+        $entity1->likeBy(1);
+        $entity2->likeBy(2);
+        $article->likeBy(1);
 
         $service->removeLikeCountersOfType(EntityWithMorphMap::class, 'LIKE');
 
@@ -137,10 +137,10 @@ class LikeableServiceTest extends TestCase
         $service = $this->app->make(LikeableServiceContract::class);
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
-        $entity1->like(1);
-        $entity1->like(2);
-        $entity2->like(1);
-        $entity2->like(4);
+        $entity1->likeBy(1);
+        $entity1->likeBy(2);
+        $entity2->likeBy(1);
+        $entity2->likeBy(4);
 
         $service->removeModelLikes($entity1, 'LIKE');
 
@@ -149,12 +149,12 @@ class LikeableServiceTest extends TestCase
     }
 
     /** @test */
-    public function it_can_remove_like_on_dislike()
+    public function it_can_remove_like_on_dislikeBy()
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->like(1);
-        $entity->dislike(1);
+        $entity->likeBy(1);
+        $entity->dislikeBy(1);
 
         $this->assertCount(1, $entity->likesAndDislikes);
         $this->assertCount(1, $entity->dislikes);
@@ -162,12 +162,12 @@ class LikeableServiceTest extends TestCase
     }
 
     /** @test */
-    public function it_can_remove_dislike_on_like()
+    public function it_can_remove_dislike_on_likeBy()
     {
         $entity = factory(Entity::class)->create();
 
-        $entity->dislike(1);
-        $entity->like(1);
+        $entity->dislikeBy(1);
+        $entity->likeBy(1);
 
         $this->assertCount(1, $entity->likesAndDislikes);
         $this->assertCount(1, $entity->likes);
@@ -181,8 +181,8 @@ class LikeableServiceTest extends TestCase
         $user1 = factory(User::class)->create();
         factory(User::class)->create();
         $user3 = factory(User::class)->create();
-        $entity->like($user1->id);
-        $entity->like($user3->id);
+        $entity->likeBy($user1->id);
+        $entity->likeBy($user3->id);
 
         $likers = app(LikeableServiceContract::class)->collectLikersOf($entity);
 
@@ -197,9 +197,9 @@ class LikeableServiceTest extends TestCase
         $user1 = factory(User::class)->create();
         $user2 = factory(User::class)->create();
         $user3 = factory(User::class)->create();
-        $entity->dislike($user1->id);
-        $entity->like($user2->id);
-        $entity->dislike($user3->id);
+        $entity->dislikeBy($user1->id);
+        $entity->likeBy($user2->id);
+        $entity->dislikeBy($user3->id);
 
         $dislikers = app(LikeableServiceContract::class)->collectDislikersOf($entity);
 

--- a/tests/Unit/Liker/Exceptions/InvalidLikerTest.php
+++ b/tests/Unit/Liker/Exceptions/InvalidLikerTest.php
@@ -29,17 +29,17 @@ class InvalidLikerTest extends TestCase
     use DatabaseTransactions;
 
     /** @test */
-    public function it_can_throw_exception_if_not_authenticated_on_like()
+    public function it_can_throw_exception_if_not_authenticated_on_likeBy()
     {
         $this->expectException(InvalidLiker::class);
 
         $entity = factory(Entity::class)->create();
 
-        $entity->like();
+        $entity->likeBy();
     }
 
     /** @test */
-    public function it_can_throw_exception_if_authenticated_but_passed_zero_on_like()
+    public function it_can_throw_exception_if_authenticated_but_passed_zero_on_likeBy()
     {
         $this->expectException(InvalidLiker::class);
 
@@ -47,21 +47,21 @@ class InvalidLikerTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
 
-        $entity->like(0);
+        $entity->likeBy(0);
     }
 
     /** @test */
-    public function it_can_throw_exception_if_not_authenticated_on_unlike()
+    public function it_can_throw_exception_if_not_authenticated_on_unlikeBy()
     {
         $this->expectException(InvalidLiker::class);
 
         $entity = factory(Entity::class)->create();
 
-        $entity->unlike();
+        $entity->unlikeBy();
     }
 
     /** @test */
-    public function it_can_throw_exception_if_authenticated_but_passed_zero_on_unlike()
+    public function it_can_throw_exception_if_authenticated_but_passed_zero_on_unlikeBy()
     {
         $this->expectException(InvalidLiker::class);
 
@@ -69,7 +69,7 @@ class InvalidLikerTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
 
-        $entity->unlike(0);
+        $entity->unlikeBy(0);
     }
 
     /** @test */

--- a/tests/Unit/Liker/Models/Traits/LikerTest.php
+++ b/tests/Unit/Liker/Models/Traits/LikerTest.php
@@ -1,0 +1,285 @@
+<?php
+
+/*
+ * This file is part of Laravel Love.
+ *
+ * (c) Anton Komarev <a.komarev@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Tests\Laravel\Love\Unit\Liker\Models\Traits;
+
+use Cog\Tests\Laravel\Love\Stubs\Models\Entity;
+use Cog\Tests\Laravel\Love\Stubs\Models\User;
+use Cog\Tests\Laravel\Love\TestCase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+/**
+ * Class LikeableTest.
+ *
+ * @package Cog\Tests\Laravel\Love\Unit\Liker\Models\Traits
+ */
+class Liker extends TestCase
+{
+    use DatabaseTransactions;
+
+    /* Likes */
+
+    /** @test */
+    public function it_can_like_likeable()
+    {
+        $entity = factory(Entity::class)->create();
+
+        $user = factory(User::class)->create();
+        $this->actingAs($user);
+
+        $user->like($entity);
+
+        $this->assertEquals(1, $entity->likesCount);
+        $this->assertEquals($user->id, $entity->likes->first()->user_id);
+    }
+
+    /** @test */
+    public function it_can_like_likeable_by_other_user()
+    {
+        $entity = factory(Entity::class)->create();
+
+        $user1 = factory(User::class)->create();
+        $user2 = factory(User::class)->create();
+        $this->actingAs($user1);
+
+        $user2->like($entity);
+
+        $this->assertEquals(1, $entity->likesCount);
+        $this->assertEquals($user2->id, $entity->likes->first()->user_id);
+    }
+
+    /** @test */
+    public function it_can_like_many_likeables()
+    {
+        $user = factory(User::class)->create();
+        $entity1 = factory(Entity::class)->create();
+        $entity2 = factory(Entity::class)->create();
+
+        $user->like($entity1);
+        $user->like($entity2);
+
+        $this->assertEquals(1, $entity1->likesCount);
+        $this->assertEquals($user->id, $entity1->likes->first()->user_id);
+        $this->assertEquals(1, $entity2->likesCount);
+        $this->assertEquals($user->id, $entity2->likes->first()->user_id);
+    }
+
+    /** @test */
+    public function it_cannot_duplicate_likes()
+    {
+        $user = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+
+        $user->like($entity);
+        $user->like($entity);
+
+        $this->assertEquals(1, $entity->likesCount);
+    }
+
+    /** @test */
+    public function it_can_unlike_likeable()
+    {
+        $user = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+        $user->like($entity);
+
+        $user->unlike($entity);
+
+        $this->assertEquals(0, $entity->likesCount);
+    }
+
+    /** @test */
+    public function it_cannot_unlike_likeable_if_not_liked()
+    {
+        $user = factory(User::class)->create();
+        $user2 = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+        $user2->like($entity);
+
+        $user->unlike($entity);
+
+        $this->assertEquals(1, $entity->likesCount);
+    }
+
+    /** @test */
+    public function it_can_add_like_with_toggle()
+    {
+        $user = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+
+        $user->toggleLike($entity);
+
+        $this->assertEquals(1, $entity->likesCount);
+    }
+
+    /** @test */
+    public function it_can_remove_like_with_toggle()
+    {
+        $user = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+        $user->like($entity);
+
+        $user->toggleLike($entity);
+
+        $this->assertEquals(0, $entity->likesCount);
+    }
+
+    /** @test */
+    public function it_can_check_if_liker_has_liked_likeable()
+    {
+        $user = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+        $user->like($entity);
+
+        $this->assertTrue($user->hasLiked($entity));
+    }
+
+    /** @test */
+    public function it_can_check_if_liker_has_not_liked_likeable()
+    {
+        $user = factory(User::class)->create();
+        $user2 = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+        $user->like($entity);
+
+        $this->assertFalse($user2->hasLiked($entity));
+    }
+
+    /* Dislikes */
+
+    /** @test */
+    public function it_can_dislike_likeable()
+    {
+        $entity = factory(Entity::class)->create();
+
+        $user = factory(User::class)->create();
+        $this->actingAs($user);
+
+        $user->dislike($entity);
+
+        $this->assertEquals(1, $entity->dislikesCount);
+        $this->assertEquals($user->id, $entity->dislikes->first()->user_id);
+    }
+
+    /** @test */
+    public function it_can_dislike_likeable_by_other_user()
+    {
+        $entity = factory(Entity::class)->create();
+
+        $user1 = factory(User::class)->create();
+        $user2 = factory(User::class)->create();
+        $this->actingAs($user1);
+
+        $user2->dislike($entity);
+
+        $this->assertEquals(1, $entity->dislikesCount);
+        $this->assertEquals($user2->id, $entity->dislikes->first()->user_id);
+    }
+
+    /** @test */
+    public function it_can_dislike_many_likeables()
+    {
+        $user = factory(User::class)->create();
+        $entity1 = factory(Entity::class)->create();
+        $entity2 = factory(Entity::class)->create();
+
+        $user->dislike($entity1);
+        $user->dislike($entity2);
+
+        $this->assertEquals(1, $entity1->dislikesCount);
+        $this->assertEquals($user->id, $entity1->dislikes->first()->user_id);
+        $this->assertEquals(1, $entity2->dislikesCount);
+        $this->assertEquals($user->id, $entity2->dislikes->first()->user_id);
+    }
+
+    /** @test */
+    public function it_cannot_duplicate_dislikes()
+    {
+        $user = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+
+        $user->dislike($entity);
+        $user->dislike($entity);
+
+        $this->assertEquals(1, $entity->dislikesCount);
+    }
+
+    /** @test */
+    public function it_can_undislike_likeable()
+    {
+        $user = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+        $user->dislike($entity);
+
+        $user->undislike($entity);
+
+        $this->assertEquals(0, $entity->likesCount);
+    }
+
+    /** @test */
+    public function it_cannot_undislike_likeable_if_not_disliked()
+    {
+        $user = factory(User::class)->create();
+        $user2 = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+        $user2->dislike($entity);
+
+        $user->undislike($entity);
+
+        $this->assertEquals(1, $entity->dislikesCount);
+    }
+
+    /** @test */
+    public function it_can_add_dislike_with_toggle()
+    {
+        $user = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+
+        $user->toggleDislike($entity);
+
+        $this->assertEquals(1, $entity->dislikesCount);
+    }
+
+    /** @test */
+    public function it_can_remove_dislike_with_toggle()
+    {
+        $user = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+        $user->dislike($entity);
+
+        $user->toggleDislike($entity);
+
+        $this->assertEquals(0, $entity->dislikesCount);
+    }
+
+    /** @test */
+    public function it_can_check_if_liker_has_disliked_likeable()
+    {
+        $user = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+        $user->dislike($entity);
+
+        $this->assertTrue($user->hasDisliked($entity));
+    }
+
+    /** @test */
+    public function it_can_check_if_liker_has_not_disliked_likeable()
+    {
+        $user = factory(User::class)->create();
+        $user2 = factory(User::class)->create();
+        $entity = factory(Entity::class)->create();
+        $user->dislike($entity);
+
+        $this->assertFalse($user2->hasDisliked($entity));
+    }
+}

--- a/tests/Unit/Liker/Models/Traits/LikerTest.php
+++ b/tests/Unit/Liker/Models/Traits/LikerTest.php
@@ -19,11 +19,11 @@ use Cog\Tests\Laravel\Love\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 /**
- * Class LikeableTest.
+ * Class LikerTest.
  *
  * @package Cog\Tests\Laravel\Love\Unit\Liker\Models\Traits
  */
-class Liker extends TestCase
+class LikerTest extends TestCase
 {
     use DatabaseTransactions;
 


### PR DESCRIPTION
The main goal of the release: make API more explicit and give an ability to extend it in future.

This PR solves #2 by adding postfix `By` to all `Likeable` methods names where Liker is passed as argument.