### PR TITLE
load migrations in provider boot method

### DIFF
--- a/src/Providers/LoveServiceProvider.php
+++ b/src/Providers/LoveServiceProvider.php
@@ -40,6 +40,7 @@ class LoveServiceProvider extends ServiceProvider
         $this->registerConsoleCommands();
         $this->registerObservers();
         $this->registerPublishes();
+        $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');
     }
 
     /**


### PR DESCRIPTION
I made this PR because Installation instructions don't work as intended.

`php artisan migrate` should work without publishing first.