### PR TITLE
Removed duplicating indexes for foreign keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-love` will be documented in this file.
 
+## [6.1.1] - 2019-03-05
+
+### Removed
+
+- Removed duplicating indexes for foreign keys
+
 ## [6.1.0] - 2019-02-26
 
 ### Added
@@ -232,8 +238,9 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 
 - Initial release
 
-[6.1.0]: https://github.com/cybercog/laravel-love/compare/v6.0.0...v6.1.0
-[6.0.0]: https://github.com/cybercog/laravel-love/compare/5.2.0...v6.0.0
+[6.1.1]: https://github.com/cybercog/laravel-love/compare/6.1.0...6.1.1
+[6.1.0]: https://github.com/cybercog/laravel-love/compare/6.0.0...6.1.0
+[6.0.0]: https://github.com/cybercog/laravel-love/compare/5.2.0...6.0.0
 [5.2.0]: https://github.com/cybercog/laravel-love/compare/5.1.1...5.2.0
 [5.1.1]: https://github.com/cybercog/laravel-love/compare/5.1.0...5.1.1
 [5.1.0]: https://github.com/cybercog/laravel-love/compare/5.0.0...5.1.0

--- a/database/migrations/2018_07_22_002000_create_love_reactions_table.php
+++ b/database/migrations/2018_07_22_002000_create_love_reactions_table.php
@@ -31,9 +31,6 @@ final class CreateLoveReactionsTable extends Migration
             $table->unsignedBigInteger('reaction_type_id');
             $table->timestamps();
 
-            $table->index('reactant_id');
-            $table->index('reacter_id');
-            $table->index('reaction_type_id');
             $table->index([
                 'reactant_id',
                 'reaction_type_id',

--- a/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
+++ b/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
@@ -32,8 +32,6 @@ final class CreateLoveReactantReactionCountersTable extends Migration
             $table->bigInteger('weight')->default(0);
             $table->timestamps();
 
-            $table->index('reactant_id');
-            $table->index('reaction_type_id');
             $table->index([
                 'reactant_id',
                 'reaction_type_id',

--- a/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
+++ b/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
@@ -31,8 +31,6 @@ final class CreateLoveReactantReactionTotalsTable extends Migration
             $table->bigInteger('weight')->default(0);
             $table->timestamps();
 
-            $table->index('reactant_id');
-
             $table
                 ->foreign('reactant_id')
                 ->references('id')


### PR DESCRIPTION
Remove single column indexes for foreign keys because `foreign` method creates them already.