### PR TITLE
Fix Laravel 5.8 support in v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: php
 
-sudo: false
-
 php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-love` will be documented in this file.
 
+## [5.2.1] - 2018-03-05
+
+### Added
+
+- ([#48](https://github.com/cybercog/laravel-love/pull/48)) Laravel 5.8 support
+
 ## [5.2.0] - 2018-09-09
 
 ### Added
@@ -184,6 +190,7 @@ All notable changes to `laravel-love` will be documented in this file.
 
 - Initial release
 
+[5.2.1]: https://github.com/cybercog/laravel-love/compare/5.2.0...5.2.1
 [5.2.0]: https://github.com/cybercog/laravel-love/compare/5.1.1...5.2.0
 [5.1.1]: https://github.com/cybercog/laravel-love/compare/5.1.0...5.1.1
 [5.1.0]: https://github.com/cybercog/laravel-love/compare/5.0.0...5.1.0

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Laravel Love simplify management of Eloquent model's likes & dislikes reactions.
 This package is a fork of the abandoned [Laravel Likeable](https://github.com/cybercog/laravel-likeable).
 It completely changes package namespace architecture, aimed to API refactoring and adding new features.
 
+**NOTICE:** Laravel Love v5 accepts support PRs only (breaking changes not allowed).
+
 ## Contents
 
 - [Features](#features)
@@ -454,8 +456,8 @@ If you discover any security related issues, please email open@cybercog.su inste
 
 ## Contributors
 
-| <a href="https://github.com/antonkomarev">![@antonkomarev](https://avatars.githubusercontent.com/u/1849174?s=110)<br />Anton Komarev</a> | <a href="https://github.com/squigg">![@squigg](https://avatars.githubusercontent.com/u/4279310?s=110)<br />Squigg</a> | <a href="https://github.com/acidjazz">![@acidjazz](https://avatars.githubusercontent.com/u/967369?s=110)<br />Kevin Olson</a> | <a href="https://github.com/raniesantos">![@raniesantos](https://avatars.githubusercontent.com/u/8528269?s=110)<br />Ranie Santos</a> |  
-| :---: | :---: | :---: | :---: |
+| <a href="https://github.com/antonkomarev">![@antonkomarev](https://avatars.githubusercontent.com/u/1849174?s=110)<br />Anton Komarev</a> | <a href="https://github.com/squigg">![@squigg](https://avatars.githubusercontent.com/u/4279310?s=110)<br />Squigg</a> | <a href="https://github.com/acidjazz">![@acidjazz](https://avatars.githubusercontent.com/u/967369?s=110)<br />Kevin Olson</a> | <a href="https://github.com/raniesantos">![@raniesantos](https://avatars.githubusercontent.com/u/8528269?s=110)<br />Ranie Santos</a> | <a href="https://github.com/taliptako">![@taliptako](https://avatars.githubusercontent.com/u/2073785?s=110)<br />Talip Durmuş</a> |  
+| :---: | :---: | :---: | :---: | :---: |
 
 [Laravel Love contributors list](../../contributors)
 

--- a/composer.json
+++ b/composer.json
@@ -51,8 +51,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",
         "mockery/mockery": "^1.0",
-        "orchestra/database": "~3.5.0|~3.6.0|~3.7.0",
-        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0",
+        "orchestra/database": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
+        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
         "phpunit/phpunit": "^6.0|^7.0"
     },
     "autoload": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love;
 
+use Cog\Laravel\Love\Providers\LoveServiceProvider;
 use Cog\Tests\Laravel\Love\Stubs\Models\EntityWithMorphMap;
 use Cog\Tests\Laravel\Love\Stubs\Models\User;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\File;
 use Mockery;
+use Orchestra\Database\ConsoleServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 /**
@@ -32,7 +34,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -50,7 +52,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
 
@@ -63,11 +65,11 @@ abstract class TestCase extends Orchestra
      * @param \Illuminate\Foundation\Application $app
      * @return array
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
-            \Cog\Laravel\Love\Providers\LoveServiceProvider::class,
-            \Orchestra\Database\ConsoleServiceProvider::class,
+            LoveServiceProvider::class,
+            ConsoleServiceProvider::class,
         ];
     }
 
@@ -76,7 +78,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function publishPackageMigrations()
+    protected function publishPackageMigrations(): void
     {
         $this->artisan('vendor:publish', [
             '--force' => '',
@@ -89,7 +91,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function destroyPackageMigrations()
+    protected function destroyPackageMigrations(): void
     {
         File::cleanDirectory(__DIR__ . '/../vendor/orchestra/testbench-core/laravel/database/migrations');
     }
@@ -99,7 +101,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function migrateUnitTestTables()
+    protected function migrateUnitTestTables(): void
     {
         $this->loadMigrationsFrom([
             '--realpath' => realpath(__DIR__ . '/database/migrations'),
@@ -111,7 +113,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function migratePackageTables()
+    protected function migratePackageTables(): void
     {
         $this->loadMigrationsFrom([
             '--realpath' => database_path('migrations'),
@@ -123,7 +125,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function registerPackageFactories()
+    protected function registerPackageFactories(): void
     {
         $pathToFactories = realpath(__DIR__ . '/database/factories');
         $this->withFactories($pathToFactories);
@@ -134,7 +136,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function registerTestMorphMaps()
+    protected function registerTestMorphMaps(): void
     {
         Relation::morphMap([
             'entity-with-morph-map' => EntityWithMorphMap::class,
@@ -146,7 +148,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function registerUserModel()
+    protected function registerUserModel(): void
     {
         $this->app['config']->set('auth.providers.users.model', User::class);
     }

--- a/tests/Unit/Console/Commands/Recount.php
+++ b/tests/Unit/Console/Commands/Recount.php
@@ -20,6 +20,7 @@ use Cog\Tests\Laravel\Love\Stubs\Models\Entity;
 use Cog\Tests\Laravel\Love\Stubs\Models\EntityWithMorphMap;
 use Cog\Tests\Laravel\Love\Stubs\Models\User;
 use Cog\Tests\Laravel\Love\TestCase;
+use Illuminate\Support\Str;
 
 /**
  * Class Recount.
@@ -28,15 +29,20 @@ use Cog\Tests\Laravel\Love\TestCase;
  */
 class Recount extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!Str::startsWith($this->app->version(), ['5.5', '5.6'])) {
+            $this->withoutMockingConsoleOutput();
+        }
+    }
+
     /* Likes */
 
     /** @test */
     public function it_can_recount_all_models_likes()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
         $article = factory(Article::class)->create();
@@ -70,10 +76,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_recount_model_likes()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
 
@@ -105,10 +107,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_recount_model_likes_using_morph_map()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
 
@@ -140,10 +138,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_recount_model_likes_with_morph_map_using_full_class_name()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
 
@@ -177,10 +171,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_recount_all_models_dislikes()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
         $article = factory(Article::class)->create();
@@ -214,10 +204,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_recount_model_dislikes()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
 
@@ -249,10 +235,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_recount_model_dislikes_using_morph_map()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
 
@@ -284,10 +266,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_recount_model_dislikes_with_morph_map_using_full_class_name()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
 
@@ -321,10 +299,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_recount_all_models_all_like_types()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
         $article = factory(Article::class)->create();
@@ -356,10 +330,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_recount_model_all_like_types()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $entity1 = factory(Entity::class)->create();
         $entity2 = factory(Entity::class)->create();
 
@@ -390,10 +360,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_recount_model_all_like_types_using_morph_map()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
 
@@ -424,10 +390,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_recount_model_all_like_types_with_morph_map_using_full_class_name()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $entity1 = factory(EntityWithMorphMap::class)->create();
         $entity2 = factory(EntityWithMorphMap::class)->create();
 
@@ -460,10 +422,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_throw_model_invalid_exception_on_not_exist_morph_map()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $this->expectException(InvalidLikeable::class);
 
         $command = $this->artisan('love:recount', [
@@ -476,10 +434,6 @@ class Recount extends TestCase
     /** @test */
     public function it_can_throw_model_invalid_exception_if_class_not_implemented_has_likes_interface()
     {
-        if ($this->isLaravelVersion('5.7')) {
-            $this->withoutMockingConsoleOutput();
-        }
-
         $this->expectException(InvalidLikeable::class);
 
         $command = $this->artisan('love:recount', [
@@ -492,10 +446,5 @@ class Recount extends TestCase
     public function it_deletes_records_before_recount()
     {
         // :TODO: Mock `removeLikeCountersOfType` method call
-    }
-
-    private function isLaravelVersion(string $version): bool
-    {
-        return starts_with($this->app->version(), $version);
     }
 }


### PR DESCRIPTION
Fixes tests and updates environment.

Continue #48 & #43 

PHP7.0 tests are disabled because there is no other way to add Laravel 5.8 support.