### PR TITLE
Fix artisan setup commands options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-love` will be documented in this file.
 
+## [6.2.1] - 2019-06-14
+
+### Added
+
+- ([#58](https://github.com/cybercog/laravel-love/pull/58)) Fix `--model` option of `love:setup-reacterable` & `love:setup-reactable` Artisan commands
+
 ## [6.2.0] - 2019-06-14
 
 ### Added
@@ -242,6 +248,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 
 - Initial release
 
+[6.2.1]: https://github.com/cybercog/laravel-love/compare/6.2.0...6.2.1
 [6.2.0]: https://github.com/cybercog/laravel-love/compare/6.1.0...6.2.0
 [6.1.0]: https://github.com/cybercog/laravel-love/compare/6.0.1...6.1.0
 [6.0.1]: https://github.com/cybercog/laravel-love/compare/6.0.0...6.0.1

--- a/src/Console/Commands/SetupReactable.php
+++ b/src/Console/Commands/SetupReactable.php
@@ -33,7 +33,7 @@ final class SetupReactable extends Command
      * @var string
      */
     protected $signature = 'love:setup-reactable
-        {model? : The name of the reactable model}
+        {--model= : The name of the reactable model}
         {--nullable : Indicate if foreign column allows null values}';
 
     /**
@@ -127,6 +127,8 @@ final class SetupReactable extends Command
             return 1;
         }
 
+        $this->info('Migration created successfully!');
+
         $this->composer->dumpAutoloads();
 
         return 0;
@@ -134,7 +136,7 @@ final class SetupReactable extends Command
 
     private function resolveModel(): string
     {
-        return $this->argument('model')
+        return $this->option('model')
             ?? $this->ask('What model should be reactable?')
             ?? $this->resolveModel();
     }

--- a/src/Console/Commands/SetupReacterable.php
+++ b/src/Console/Commands/SetupReacterable.php
@@ -33,7 +33,7 @@ final class SetupReacterable extends Command
      * @var string
      */
     protected $signature = 'love:setup-reacterable
-        {model? : The name of the reacterable model}
+        {--model= : The name of the reacterable model}
         {--nullable : Indicate if foreign column allows null values}';
 
     /**
@@ -127,6 +127,8 @@ final class SetupReacterable extends Command
             return 1;
         }
 
+        $this->info('Migration created successfully!');
+
         $this->composer->dumpAutoloads();
 
         return 0;
@@ -134,7 +136,7 @@ final class SetupReacterable extends Command
 
     private function resolveModel(): string
     {
-        return $this->argument('model')
+        return $this->option('model')
             ?? $this->ask('What model should be reacterable?')
             ?? $this->resolveModel();
     }

--- a/tests/Unit/Console/Commands/SetupReactableTest.php
+++ b/tests/Unit/Console/Commands/SetupReactableTest.php
@@ -41,7 +41,7 @@ final class SetupReactableTest extends TestCase
     public function it_can_create_migration_for_reactable_model(): void
     {
         $status = $this->artisan('love:setup-reactable', [
-            'model' => Person::class,
+            '--model' => Person::class,
         ]);
 
         $this->assertSame(0, $status);
@@ -54,7 +54,7 @@ final class SetupReactableTest extends TestCase
     public function it_can_create_migration_for_reactable_model_with_nullable_column(): void
     {
         $status = $this->artisan('love:setup-reactable', [
-            'model' => Person::class,
+            '--model' => Person::class,
             '--nullable' => true,
         ]);
 
@@ -68,7 +68,7 @@ final class SetupReactableTest extends TestCase
     public function it_cannot_create_migration_for_reactable_model_when_model_not_exists(): void
     {
         $status = $this->artisan('love:setup-reactable', [
-            'model' => 'NotExists',
+            '--model' => 'NotExists',
         ]);
 
         $this->assertSame(1, $status);
@@ -79,7 +79,7 @@ final class SetupReactableTest extends TestCase
     public function it_cannot_create_migration_for_reactable_model_when_model_not_implements_reactable_contract(): void
     {
         $status = $this->artisan('love:setup-reactable', [
-            'model' => Bot::class,
+            '--model' => Bot::class,
         ]);
 
         $this->assertSame(1, $status);
@@ -91,7 +91,7 @@ final class SetupReactableTest extends TestCase
     {
         Schema::drop('love_reactants');
         $status = $this->artisan('love:setup-reactable', [
-            'model' => Person::class,
+            '--model' => Person::class,
         ]);
 
         $this->assertSame(1, $status);
@@ -102,7 +102,7 @@ final class SetupReactableTest extends TestCase
     public function it_cannot_create_migration_for_reactable_model_when_column_already_exists(): void
     {
         $status = $this->artisan('love:setup-reactable', [
-            'model' => Article::class,
+            '--model' => Article::class,
         ]);
 
         $this->assertSame(1, $status);

--- a/tests/Unit/Console/Commands/SetupReacterableTest.php
+++ b/tests/Unit/Console/Commands/SetupReacterableTest.php
@@ -41,7 +41,7 @@ final class SetupReacterableTest extends TestCase
     public function it_can_create_migration_for_reacterable_model(): void
     {
         $status = $this->artisan('love:setup-reacterable', [
-            'model' => Person::class,
+            '--model' => Person::class,
         ]);
 
         $this->assertSame(0, $status);
@@ -54,7 +54,7 @@ final class SetupReacterableTest extends TestCase
     public function it_can_create_migration_for_reacterable_model_with_nullable_column(): void
     {
         $status = $this->artisan('love:setup-reacterable', [
-            'model' => Person::class,
+            '--model' => Person::class,
             '--nullable' => true,
         ]);
 
@@ -68,7 +68,7 @@ final class SetupReacterableTest extends TestCase
     public function it_cannot_create_migration_for_reacterable_model_when_model_not_exists(): void
     {
         $status = $this->artisan('love:setup-reacterable', [
-            'model' => 'NotExists',
+            '--model' => 'NotExists',
         ]);
 
         $this->assertSame(1, $status);
@@ -79,7 +79,7 @@ final class SetupReacterableTest extends TestCase
     public function it_cannot_create_migration_for_reacterable_model_when_model_not_implements_reacterable_contract(): void
     {
         $status = $this->artisan('love:setup-reacterable', [
-            'model' => Article::class,
+            '--model' => Article::class,
         ]);
 
         $this->assertSame(1, $status);
@@ -91,7 +91,7 @@ final class SetupReacterableTest extends TestCase
     {
         Schema::drop('love_reacters');
         $status = $this->artisan('love:setup-reacterable', [
-            'model' => Person::class,
+            '--model' => Person::class,
         ]);
 
         $this->assertSame(1, $status);
@@ -102,7 +102,7 @@ final class SetupReacterableTest extends TestCase
     public function it_cannot_create_migration_for_reacterable_model_when_column_already_exists(): void
     {
         $status = $this->artisan('love:setup-reacterable', [
-            'model' => User::class,
+            '--model' => User::class,
         ]);
 
         $this->assertSame(1, $status);


### PR DESCRIPTION
Artisan commands `love:setup-reacterable` & `love:setup-reactable` should receive model as option, not as argument.