### PR TITLE
Fix Reacter facade boolean method names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-love` will be documented in this file.
 
+## [7.0.1] - 2019-06-22
+
+### Changed
+
+- ([#70](https://github.com/cybercog/laravel-love/pull/70)) `hasReactedTo` & `hasNotReactedTo` methods names of `Reacter` facade were changed
+
 ## [7.0.0] - 2019-06-22
 
 ### Added
@@ -260,6 +266,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 
 - Initial release
 
+[7.0.1]: https://github.com/cybercog/laravel-love/compare/7.0.0...7.0.1
 [7.0.0]: https://github.com/cybercog/laravel-love/compare/6.2.1...7.0.0
 [6.2.1]: https://github.com/cybercog/laravel-love/compare/6.2.0...6.2.1
 [6.2.0]: https://github.com/cybercog/laravel-love/compare/6.1.0...6.2.0

--- a/contracts/Reacter/Facades/Reacter.php
+++ b/contracts/Reacter/Facades/Reacter.php
@@ -23,7 +23,7 @@ interface Reacter
 
     public function unreactTo(Reactable $reactable, string $reactionTypeName): void;
 
-    public function isReactedTo(Reactable $reactable, ?string $reactionTypeName = null): bool;
+    public function hasReactedTo(Reactable $reactable, ?string $reactionTypeName = null): bool;
 
-    public function isNotReactedTo(Reactable $reactable, ?string $reactionTypeName = null): bool;
+    public function hasNotReactedTo(Reactable $reactable, ?string $reactionTypeName = null): bool;
 }

--- a/src/Reacter/Facades/Reacter.php
+++ b/src/Reacter/Facades/Reacter.php
@@ -52,7 +52,7 @@ final class Reacter implements ReacterFacadeContract
         );
     }
 
-    public function isReactedTo(
+    public function hasReactedTo(
         ReactableContract $reactable,
         ?string $reactionTypeName = null
     ): bool {
@@ -68,7 +68,7 @@ final class Reacter implements ReacterFacadeContract
         );
     }
 
-    public function isNotReactedTo(
+    public function hasNotReactedTo(
         ReactableContract $reactable,
         ?string $reactionTypeName = null
     ): bool {

--- a/tests/Unit/Reacter/Facades/ReacterTest.php
+++ b/tests/Unit/Reacter/Facades/ReacterTest.php
@@ -219,7 +219,7 @@ final class ReacterTest extends TestCase
             'reactant_id' => $reactant->getId(),
         ]);
 
-        $isReacted = $reacterFacade->isReactedTo($reactable);
+        $isReacted = $reacterFacade->hasReactedTo($reactable);
 
         $this->assertTrue($isReacted);
     }
@@ -231,7 +231,7 @@ final class ReacterTest extends TestCase
         $reacterFacade = new ReacterFacade($reacter);
         $reactable = factory(ArticleWithoutAutoReactantCreate::class)->create();
 
-        $isReacted = $reacterFacade->isReactedTo($reactable);
+        $isReacted = $reacterFacade->hasReactedTo($reactable);
 
         $this->assertFalse($isReacted);
     }
@@ -243,7 +243,7 @@ final class ReacterTest extends TestCase
         $reacterFacade = new ReacterFacade($reacter);
         $reactable = new Article();
 
-        $isReacted = $reacterFacade->isReactedTo($reactable);
+        $isReacted = $reacterFacade->hasReactedTo($reactable);
 
         $this->assertFalse($isReacted);
     }
@@ -265,7 +265,7 @@ final class ReacterTest extends TestCase
             'reactant_id' => $reactant->getId(),
         ]);
 
-        $isNotReacted = $reacterFacade->isNotReactedTo($reactable);
+        $isNotReacted = $reacterFacade->hasNotReactedTo($reactable);
 
         $this->assertTrue($isNotReacted);
     }
@@ -277,7 +277,7 @@ final class ReacterTest extends TestCase
         $reacterFacade = new ReacterFacade($reacter);
         $reactable = factory(ArticleWithoutAutoReactantCreate::class)->create();
 
-        $isNotReacted = $reacterFacade->isNotReactedTo($reactable);
+        $isNotReacted = $reacterFacade->hasNotReactedTo($reactable);
 
         $this->assertTrue($isNotReacted);
     }
@@ -289,7 +289,7 @@ final class ReacterTest extends TestCase
         $reacterFacade = new ReacterFacade($reacter);
         $reactable = new Article();
 
-        $isNotReacted = $reacterFacade->isNotReactedTo($reactable);
+        $isNotReacted = $reacterFacade->hasNotReactedTo($reactable);
 
         $this->assertTrue($isNotReacted);
     }
@@ -308,7 +308,7 @@ final class ReacterTest extends TestCase
             'reactant_id' => $reactant->getId(),
         ]);
 
-        $isReacted = $reacterFacade->isReactedTo($reactable, $reactionType->getName());
+        $isReacted = $reacterFacade->hasReactedTo($reactable, $reactionType->getName());
 
         $this->assertTrue($isReacted);
     }
@@ -321,7 +321,7 @@ final class ReacterTest extends TestCase
         $reactable = factory(ArticleWithoutAutoReactantCreate::class)->create();
         $reactionType = factory(ReactionType::class)->create();
 
-        $isReacted = $reacterFacade->isReactedTo($reactable, $reactionType->getName());
+        $isReacted = $reacterFacade->hasReactedTo($reactable, $reactionType->getName());
 
         $this->assertFalse($isReacted);
     }
@@ -334,7 +334,7 @@ final class ReacterTest extends TestCase
         $reactable = new Article();
         $reactionType = factory(ReactionType::class)->create();
 
-        $isReacted = $reacterFacade->isReactedTo($reactable, $reactionType->getName());
+        $isReacted = $reacterFacade->hasReactedTo($reactable, $reactionType->getName());
 
         $this->assertFalse($isReacted);
     }
@@ -348,7 +348,7 @@ final class ReacterTest extends TestCase
         $reacterFacade = new ReacterFacade($reacter);
         $reactable = factory(Article::class)->create();
 
-        $reacterFacade->isReactedTo($reactable, 'NotExist');
+        $reacterFacade->hasReactedTo($reactable, 'NotExist');
     }
 
     /** @test */
@@ -370,7 +370,7 @@ final class ReacterTest extends TestCase
             'reactant_id' => $reactant->getId(),
         ]);
 
-        $isNotReacted = $reacterFacade->isNotReactedTo($reactable, $reactionType->getName());
+        $isNotReacted = $reacterFacade->hasNotReactedTo($reactable, $reactionType->getName());
 
         $this->assertTrue($isNotReacted);
     }
@@ -383,7 +383,7 @@ final class ReacterTest extends TestCase
         $reactable = factory(ArticleWithoutAutoReactantCreate::class)->create();
         $reactionType = factory(ReactionType::class)->create();
 
-        $isNotReacted = $reacterFacade->isNotReactedTo($reactable, $reactionType->getName());
+        $isNotReacted = $reacterFacade->hasNotReactedTo($reactable, $reactionType->getName());
 
         $this->assertTrue($isNotReacted);
     }
@@ -396,7 +396,7 @@ final class ReacterTest extends TestCase
         $reactable = new Article();
         $reactionType = factory(ReactionType::class)->create();
 
-        $isNotReacted = $reacterFacade->isNotReactedTo($reactable, $reactionType->getName());
+        $isNotReacted = $reacterFacade->hasNotReactedTo($reactable, $reactionType->getName());
 
         $this->assertTrue($isNotReacted);
     }
@@ -410,6 +410,6 @@ final class ReacterTest extends TestCase
         $reacterFacade = new ReacterFacade($reacter);
         $reactable = factory(Article::class)->create();
 
-        $reacterFacade->isNotReactedTo($reactable, 'NotExist');
+        $reacterFacade->hasNotReactedTo($reactable, 'NotExist');
     }
 }


### PR DESCRIPTION
This PR fixes boolean check methods names.

Despite the fact it's a breaking change - I'm publishing it as hotfix because it was designed and documented as `hasReactedTo` & `hasNotReactedTo`, but I copy-pasted `isReactedTo` & `isNotReactedTo` by mistake. *Publishing releases late night is bad.*