### PR TITLE
Return Collection instead of array in iterable Null objects methods

### DIFF
--- a/src/Reactant/Models/NullReactant.php
+++ b/src/Reactant/Models/NullReactant.php
@@ -22,6 +22,7 @@ use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
 use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\NullReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\NullReactionTotal;
+use Illuminate\Support\Collection;
 use TypeError;
 
 final class NullReactant implements
@@ -47,12 +48,12 @@ final class NullReactant implements
 
     public function getReactions(): iterable
     {
-        return [];
+        return new Collection();
     }
 
     public function getReactionCounters(): iterable
     {
-        return [];
+        return new Collection();
     }
 
     public function getReactionCounterOfType(

--- a/src/Reacter/Models/NullReacter.php
+++ b/src/Reacter/Models/NullReacter.php
@@ -18,6 +18,7 @@ use Cog\Contracts\Love\Reacter\Exceptions\ReacterInvalid;
 use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
 use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
 use Cog\Contracts\Love\ReactionType\Models\ReactionType;
+use Illuminate\Support\Collection;
 use TypeError;
 
 final class NullReacter implements
@@ -43,7 +44,7 @@ final class NullReacter implements
 
     public function getReactions(): iterable
     {
-        return [];
+        return new Collection();
     }
 
     public function reactTo(

--- a/tests/Unit/Reactant/Models/NullReactantTest.php
+++ b/tests/Unit/Reactant/Models/NullReactantTest.php
@@ -22,6 +22,7 @@ use Cog\Laravel\Love\Reacter\Models\Reacter;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Tests\Laravel\Love\Stubs\Models\Article;
 use Cog\Tests\Laravel\Love\TestCase;
+use Illuminate\Support\Collection;
 use TypeError;
 
 final class NullReactantTest extends TestCase
@@ -59,6 +60,16 @@ final class NullReactantTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_reactions_collection(): void
+    {
+        $reactant = new NullReactant(new Article());
+
+        $reactions = $reactant->getReactions();
+
+        $this->assertInstanceOf(Collection::class, $reactions);
+    }
+
+    /** @test */
     public function it_can_get_reaction_counters(): void
     {
         $reactant = new NullReactant(new Article());
@@ -67,6 +78,16 @@ final class NullReactantTest extends TestCase
 
         $this->assertCount(0, $counters);
         $this->assertIsIterable($counters);
+    }
+
+    /** @test */
+    public function it_can_get_reaction_counters_collection(): void
+    {
+        $reactant = new NullReactant(new Article());
+
+        $counters = $reactant->getReactionCounters();
+
+        $this->assertInstanceOf(Collection::class, $counters);
     }
 
     /** @test */

--- a/tests/Unit/Reacter/Models/NullReacterTest.php
+++ b/tests/Unit/Reacter/Models/NullReacterTest.php
@@ -23,6 +23,7 @@ use Cog\Tests\Laravel\Love\Stubs\Models\Article;
 use Cog\Tests\Laravel\Love\Stubs\Models\Bot;
 use Cog\Tests\Laravel\Love\Stubs\Models\User;
 use Cog\Tests\Laravel\Love\TestCase;
+use Illuminate\Support\Collection;
 use TypeError;
 
 final class NullReacterTest extends TestCase
@@ -57,6 +58,16 @@ final class NullReacterTest extends TestCase
 
         $this->assertCount(0, $reactions);
         $this->assertIsIterable($reactions);
+    }
+
+    /** @test */
+    public function it_can_get_reactions_collection(): void
+    {
+        $reacter = new NullReacter(new User());
+
+        $reactions = $reacter->getReactions();
+
+        $this->assertInstanceOf(Collection::class, $reactions);
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #76

Returns `Illuminate\Support\Collection` instead or `array` in `NullReactant` & `NullReacter` iterable methods.