### PR TITLE
Merge similar boolean methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `laravel-love` will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reacter model `isReactedTo` & `isReactedToWithType` methods replaced with single `hasReactedTo` method
+- ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reacter model `isNotReactedTo` & `isNotReactedToWithType` methods replaced with single `hasNotReactedTo` method
+- ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reactant model `isReactedBy`&& `isReactedByWithType` methods replaced with single `isReactedBy` method
+- ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reactant model `isNotReactedBy`&& `isNotReactedByWithType` methods replaced with single `isNotReactedBy` method
+
 ## [7.2.1] - 2019-07-11
 
 ### Fixed
@@ -284,6 +293,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 
 - Initial release
 
+[Unreleased]: https://github.com/cybercog/laravel-love/compare/7.2.1...master
 [7.2.1]: https://github.com/cybercog/laravel-love/compare/7.2.0...7.2.1
 [7.2.0]: https://github.com/cybercog/laravel-love/compare/7.1.0...7.2.0
 [7.1.0]: https://github.com/cybercog/laravel-love/compare/7.0.1...7.1.0

--- a/contracts/Reactant/Models/Reactant.php
+++ b/contracts/Reactant/Models/Reactant.php
@@ -39,13 +39,9 @@ interface Reactant
 
     public function getReactionTotal(): ReactionTotal;
 
-    public function isReactedBy(Reacter $reacter): bool;
+    public function isReactedBy(Reacter $reacter, ?ReactionType $reactionType = null): bool;
 
-    public function isNotReactedBy(Reacter $reacter): bool;
-
-    public function isReactedByWithType(Reacter $reacter, ReactionType $type): bool;
-
-    public function isNotReactedByWithType(Reacter $reacter, ReactionType $type): bool;
+    public function isNotReactedBy(Reacter $reacter, ?ReactionType $reactionType = null): bool;
 
     public function isEqualTo(self $that): bool;
 

--- a/contracts/Reacter/Models/Reacter.php
+++ b/contracts/Reacter/Models/Reacter.php
@@ -28,17 +28,13 @@ interface Reacter
      */
     public function getReactions(): iterable;
 
-    public function reactTo(Reactant $reactant, ReactionType $type): void;
+    public function reactTo(Reactant $reactant, ReactionType $reactionType): void;
 
-    public function unreactTo(Reactant $reactant, ReactionType $type): void;
+    public function unreactTo(Reactant $reactant, ReactionType $reactionType): void;
 
-    public function isReactedTo(Reactant $reactant): bool;
+    public function hasReactedTo(Reactant $reactant, ?ReactionType $reactionType = null): bool;
 
-    public function isNotReactedTo(Reactant $reactant): bool;
-
-    public function isReactedToWithType(Reactant $reactant, ReactionType $type): bool;
-
-    public function isNotReactedToWithType(Reactant $reactant, ReactionType $type): bool;
+    public function hasNotReactedTo(Reactant $reactant, ?ReactionType $reactionType = null): bool;
 
     public function isEqualTo(self $that): bool;
 

--- a/src/Reactant/Facades/Reactant.php
+++ b/src/Reactant/Facades/Reactant.php
@@ -56,15 +56,11 @@ final class Reactant implements ReacterFacadeContract
         ReacterableContract $reacterable,
         ?string $reactionTypeName = null
     ): bool {
-        if (is_null($reactionTypeName)) {
-            return $this->reactant->isReactedBy(
-                $reacterable->getLoveReacter()
-            );
-        }
+        $reactionType = is_null($reactionTypeName) ? null : ReactionType::fromName($reactionTypeName);
 
         return $this->reactant->isReactedBy(
             $reacterable->getLoveReacter(),
-            ReactionType::fromName($reactionTypeName)
+            $reactionType
         );
     }
 
@@ -72,15 +68,11 @@ final class Reactant implements ReacterFacadeContract
         ReacterableContract $reacterable,
         ?string $reactionTypeName = null
     ): bool {
-        if (is_null($reactionTypeName)) {
-            return $this->reactant->isNotReactedBy(
-                $reacterable->getLoveReacter()
-            );
-        }
+        $reactionType = is_null($reactionTypeName) ? null : ReactionType::fromName($reactionTypeName);
 
         return $this->reactant->isNotReactedBy(
             $reacterable->getLoveReacter(),
-            ReactionType::fromName($reactionTypeName)
+            $reactionType
         );
     }
 }

--- a/src/Reactant/Facades/Reactant.php
+++ b/src/Reactant/Facades/Reactant.php
@@ -62,7 +62,7 @@ final class Reactant implements ReacterFacadeContract
             );
         }
 
-        return $this->reactant->isReactedByWithType(
+        return $this->reactant->isReactedBy(
             $reacterable->getLoveReacter(),
             ReactionType::fromName($reactionTypeName)
         );
@@ -78,7 +78,7 @@ final class Reactant implements ReacterFacadeContract
             );
         }
 
-        return $this->reactant->isNotReactedByWithType(
+        return $this->reactant->isNotReactedBy(
             $reacterable->getLoveReacter(),
             ReactionType::fromName($reactionTypeName)
         );

--- a/src/Reactant/Models/NullReactant.php
+++ b/src/Reactant/Models/NullReactant.php
@@ -68,27 +68,15 @@ final class NullReactant implements
     }
 
     public function isReactedBy(
-        ReacterContract $reacter
+        ReacterContract $reacter,
+        ?ReactionTypeContract $reactionType = null
     ): bool {
         return false;
     }
 
     public function isNotReactedBy(
-        ReacterContract $reacter
-    ): bool {
-        return true;
-    }
-
-    public function isReactedByWithType(
         ReacterContract $reacter,
-        ReactionTypeContract $reactionType
-    ): bool {
-        return false;
-    }
-
-    public function isNotReactedByWithType(
-        ReacterContract $reacter,
-        ReactionTypeContract $reactionType
+        ?ReactionTypeContract $reactionType = null
     ): bool {
         return true;
     }

--- a/src/Reactant/Models/Reactant.php
+++ b/src/Reactant/Models/Reactant.php
@@ -125,20 +125,13 @@ final class Reactant extends Model implements
 
         // TODO: Test if relation was loaded partially
         if ($this->relationLoaded('reactions')) {
-            if (!is_null($reactionType)) {
-                return $this
-                    ->getAttribute('reactions')
-                    ->contains(function (ReactionContract $reaction) use ($reacter, $reactionType) {
-                        return $reaction->isByReacter($reacter)
-                            && $reaction->isOfType($reactionType);
-                    });
-            } else {
-                return $this
-                    ->getAttribute('reactions')
-                    ->contains(function (ReactionContract $reaction) use ($reacter) {
-                        return $reaction->isByReacter($reacter);
-                    });
-            }
+            return $this
+                ->getAttribute('reactions')
+                ->contains(function (ReactionContract $reaction) use ($reacter, $reactionType) {
+                    return is_null($reactionType)
+                        ? $reaction->isByReacter($reacter)
+                        : $reaction->isByReacter($reacter) && $reaction->isOfType($reactionType);
+                });
         }
 
         $query = $this->reactions()->where('reacter_id', $reacter->getId());

--- a/src/Reactant/Models/Reactant.php
+++ b/src/Reactant/Models/Reactant.php
@@ -123,34 +123,31 @@ final class Reactant extends Model implements
             return false;
         }
 
-        if (!is_null($reactionType)) {
-            if ($this->relationLoaded('reactions')) {
+        // TODO: Test if relation was loaded partially
+        if ($this->relationLoaded('reactions')) {
+            if (!is_null($reactionType)) {
                 return $this
                     ->getAttribute('reactions')
                     ->contains(function (ReactionContract $reaction) use ($reacter, $reactionType) {
                         return $reaction->isByReacter($reacter)
                             && $reaction->isOfType($reactionType);
                     });
+            } else {
+                return $this
+                    ->getAttribute('reactions')
+                    ->contains(function (ReactionContract $reaction) use ($reacter) {
+                        return $reaction->isByReacter($reacter);
+                    });
             }
-
-            return $this->reactions()->where([
-                'reaction_type_id' => $reactionType->getId(),
-                'reacter_id' => $reacter->getId(),
-            ])->exists();
         }
 
-        // TODO: Test if relation was loaded partially
-        if ($this->relationLoaded('reactions')) {
-            return $this
-                ->getAttribute('reactions')
-                ->contains(function (ReactionContract $reaction) use ($reacter) {
-                    return $reaction->isByReacter($reacter);
-                });
+        $query = $this->reactions()->where('reacter_id', $reacter->getId());
+
+        if (!is_null($reactionType)) {
+            $query->where('reaction_type_id', $reactionType->getId());
         }
 
-        return $this->reactions()->where([
-            'reacter_id' => $reacter->getId(),
-        ])->exists();
+        return $query->exists();
     }
 
     public function isNotReactedBy(

--- a/src/Reacter/Facades/Reacter.php
+++ b/src/Reacter/Facades/Reacter.php
@@ -57,12 +57,12 @@ final class Reacter implements ReacterFacadeContract
         ?string $reactionTypeName = null
     ): bool {
         if (is_null($reactionTypeName)) {
-            return $this->reacter->isReactedTo(
+            return $this->reacter->hasReactedTo(
                 $reactable->getLoveReactant()
             );
         }
 
-        return $this->reacter->isReactedToWithType(
+        return $this->reacter->hasReactedTo(
             $reactable->getLoveReactant(),
             ReactionType::fromName($reactionTypeName)
         );
@@ -73,12 +73,12 @@ final class Reacter implements ReacterFacadeContract
         ?string $reactionTypeName = null
     ): bool {
         if (is_null($reactionTypeName)) {
-            return $this->reacter->isNotReactedTo(
+            return $this->reacter->hasNotReactedTo(
                 $reactable->getLoveReactant()
             );
         }
 
-        return $this->reacter->isNotReactedToWithType(
+        return $this->reacter->hasNotReactedTo(
             $reactable->getLoveReactant(),
             ReactionType::fromName($reactionTypeName)
         );

--- a/src/Reacter/Facades/Reacter.php
+++ b/src/Reacter/Facades/Reacter.php
@@ -56,15 +56,11 @@ final class Reacter implements ReacterFacadeContract
         ReactableContract $reactable,
         ?string $reactionTypeName = null
     ): bool {
-        if (is_null($reactionTypeName)) {
-            return $this->reacter->hasReactedTo(
-                $reactable->getLoveReactant()
-            );
-        }
+        $reactionType = is_null($reactionTypeName) ? null : ReactionType::fromName($reactionTypeName);
 
         return $this->reacter->hasReactedTo(
             $reactable->getLoveReactant(),
-            ReactionType::fromName($reactionTypeName)
+            $reactionType
         );
     }
 
@@ -72,15 +68,11 @@ final class Reacter implements ReacterFacadeContract
         ReactableContract $reactable,
         ?string $reactionTypeName = null
     ): bool {
-        if (is_null($reactionTypeName)) {
-            return $this->reacter->hasNotReactedTo(
-                $reactable->getLoveReactant()
-            );
-        }
+        $reactionType = is_null($reactionTypeName) ? null : ReactionType::fromName($reactionTypeName);
 
         return $this->reacter->hasNotReactedTo(
             $reactable->getLoveReactant(),
-            ReactionType::fromName($reactionTypeName)
+            $reactionType
         );
     }
 }

--- a/src/Reacter/Models/NullReacter.php
+++ b/src/Reacter/Models/NullReacter.php
@@ -61,28 +61,16 @@ final class NullReacter implements
         throw ReacterInvalid::notExists();
     }
 
-    public function isReactedTo(
-        Reactant $reactant
+    public function hasReactedTo(
+        Reactant $reactant,
+        ?ReactionType $reactionType = null
     ): bool {
         return false;
     }
 
-    public function isNotReactedTo(
-        Reactant $reactant
-    ): bool {
-        return true;
-    }
-
-    public function isReactedToWithType(
+    public function hasNotReactedTo(
         Reactant $reactant,
-        ReactionType $reactionType
-    ): bool {
-        return false;
-    }
-
-    public function isNotReactedToWithType(
-        Reactant $reactant,
-        ReactionType $reactionType
+        ?ReactionType $reactionType = null
     ): bool {
         return true;
     }

--- a/src/Reacter/Models/Reacter.php
+++ b/src/Reacter/Models/Reacter.php
@@ -78,7 +78,7 @@ final class Reacter extends Model implements
             throw ReactantInvalid::notExists();
         }
 
-        if ($this->isReactedToWithType($reactant, $reactionType)) {
+        if ($this->hasReactedTo($reactant, $reactionType)) {
             throw new ReactionAlreadyExists(
                 sprintf('Reaction of type `%s` already exists.', $reactionType->getName())
             );
@@ -112,38 +112,22 @@ final class Reacter extends Model implements
         $reaction->delete();
     }
 
-    public function isReactedTo(
-        ReactantContract $reactant
+    public function hasReactedTo(
+        ReactantContract $reactant,
+        ?ReactionTypeContract $reactionType = null
     ): bool {
         if ($reactant->isNull()) {
             return false;
         }
 
-        return $reactant->isReactedBy($this);
+        return $reactant->isReactedBy($this, $reactionType);
     }
 
-    public function isNotReactedTo(
-        ReactantContract $reactant
-    ): bool {
-        return !$this->isReactedTo($reactant);
-    }
-
-    public function isReactedToWithType(
+    public function hasNotReactedTo(
         ReactantContract $reactant,
-        ReactionTypeContract $reactionType
+        ?ReactionTypeContract $reactionType = null
     ): bool {
-        if ($reactant->isNull()) {
-            return false;
-        }
-
-        return $reactant->isReactedByWithType($this, $reactionType);
-    }
-
-    public function isNotReactedToWithType(
-        ReactantContract $reactant,
-        ReactionTypeContract $reactionType
-    ): bool {
-        return !$this->isReactedToWithType($reactant, $reactionType);
+        return $reactant->isNotReactedBy($this, $reactionType);
     }
 
     public function isEqualTo(

--- a/tests/Unit/Reactant/Models/NullReactantTest.php
+++ b/tests/Unit/Reactant/Models/NullReactantTest.php
@@ -245,7 +245,7 @@ final class NullReactantTest extends TestCase
         $reacter = factory(Reacter::class)->make();
         $reactionType = new ReactionType();
 
-        $isReacted = $reactant->isReactedByWithType($reacter, $reactionType);
+        $isReacted = $reactant->isReactedBy($reacter, $reactionType);
 
         $this->assertFalse($isReacted);
     }
@@ -257,7 +257,7 @@ final class NullReactantTest extends TestCase
         $reacter = factory(Reacter::class)->make();
         $reactionType = new ReactionType();
 
-        $isReacted = $reactant->isNotReactedByWithType($reacter, $reactionType);
+        $isReacted = $reactant->isNotReactedBy($reacter, $reactionType);
 
         $this->assertTrue($isReacted);
     }

--- a/tests/Unit/Reactant/Models/ReactantTest.php
+++ b/tests/Unit/Reactant/Models/ReactantTest.php
@@ -399,7 +399,7 @@ final class ReactantTest extends TestCase
             'reactant_id' => $reactant->getId(),
         ]);
 
-        $isReacted = $reactant->isReactedByWithType($reacter, $reactionType);
+        $isReacted = $reactant->isReactedBy($reacter, $reactionType);
 
         $this->assertTrue($isReacted);
     }
@@ -411,7 +411,7 @@ final class ReactantTest extends TestCase
         $reacter = new NullReacter(new Bot());
         $reactant = factory(Reactant::class)->create();
 
-        $isReacted = $reactant->isReactedByWithType($reacter, $reactionType);
+        $isReacted = $reactant->isReactedBy($reacter, $reactionType);
 
         $this->assertFalse($isReacted);
     }
@@ -423,7 +423,7 @@ final class ReactantTest extends TestCase
         $reacter = new Reacter();
         $reactant = factory(Reactant::class)->create();
 
-        $isReacted = $reactant->isReactedByWithType($reacter, $reactionType);
+        $isReacted = $reactant->isReactedBy($reacter, $reactionType);
 
         $this->assertFalse($isReacted);
     }
@@ -445,7 +445,7 @@ final class ReactantTest extends TestCase
             'reactant_id' => $reactant->getId(),
         ]);
 
-        $isNotReacted = $reactant->isNotReactedByWithType($reacter, $reactionType);
+        $isNotReacted = $reactant->isNotReactedBy($reacter, $reactionType);
 
         $this->assertTrue($isNotReacted);
     }
@@ -457,7 +457,7 @@ final class ReactantTest extends TestCase
         $reacter = new NullReacter(new Bot());
         $reactant = factory(Reactant::class)->create();
 
-        $isNotReacted = $reactant->isNotReactedByWithType($reacter, $reactionType);
+        $isNotReacted = $reactant->isNotReactedBy($reacter, $reactionType);
 
         $this->assertTrue($isNotReacted);
     }
@@ -469,7 +469,7 @@ final class ReactantTest extends TestCase
         $reacter = new Reacter();
         $reactant = factory(Reactant::class)->create();
 
-        $isNotReacted = $reactant->isNotReactedByWithType($reacter, $reactionType);
+        $isNotReacted = $reactant->isNotReactedBy($reacter, $reactionType);
 
         $this->assertTrue($isNotReacted);
     }

--- a/tests/Unit/Reacter/Models/NullReacterTest.php
+++ b/tests/Unit/Reacter/Models/NullReacterTest.php
@@ -197,7 +197,7 @@ final class NullReacterTest extends TestCase
         $reacter = new NullReacter($reacterable);
         $reactant = factory(Reactant::class)->make();
 
-        $isReacted = $reacter->isReactedTo($reactant);
+        $isReacted = $reacter->hasReactedTo($reactant);
 
         $this->assertFalse($isReacted);
     }
@@ -209,7 +209,7 @@ final class NullReacterTest extends TestCase
         $reacter = new NullReacter($reacterable);
         $reactant = factory(Reactant::class)->make();
 
-        $isReacted = $reacter->isNotReactedTo($reactant);
+        $isReacted = $reacter->hasNotReactedTo($reactant);
 
         $this->assertTrue($isReacted);
     }
@@ -222,7 +222,7 @@ final class NullReacterTest extends TestCase
         $reactant = factory(Reactant::class)->make();
         $reactionType = new ReactionType();
 
-        $isReacted = $reacter->isReactedToWithType($reactant, $reactionType);
+        $isReacted = $reacter->hasReactedTo($reactant, $reactionType);
 
         $this->assertFalse($isReacted);
     }
@@ -235,7 +235,7 @@ final class NullReacterTest extends TestCase
         $reactant = factory(Reactant::class)->make();
         $reactionType = new ReactionType();
 
-        $isReacted = $reacter->isNotReactedToWithType($reactant, $reactionType);
+        $isReacted = $reacter->hasNotReactedTo($reactant, $reactionType);
 
         $this->assertTrue($isReacted);
     }

--- a/tests/Unit/Reacter/Models/ReacterTest.php
+++ b/tests/Unit/Reacter/Models/ReacterTest.php
@@ -292,7 +292,7 @@ final class ReacterTest extends TestCase
             'reactant_id' => $reactant->getId(),
         ]);
 
-        $isReacted = $reacter->isReactedTo($reactant);
+        $isReacted = $reacter->hasReactedTo($reactant);
 
         $this->assertTrue($isReacted);
     }
@@ -303,7 +303,7 @@ final class ReacterTest extends TestCase
         $reacter = factory(Reacter::class)->create();
         $reactant = new NullReactant(new Article());
 
-        $isReacted = $reacter->isReactedTo($reactant);
+        $isReacted = $reacter->hasReactedTo($reactant);
 
         $this->assertFalse($isReacted);
     }
@@ -314,7 +314,7 @@ final class ReacterTest extends TestCase
         $reacter = factory(Reacter::class)->create();
         $reactant = Reactant::query()->make();
 
-        $isReacted = $reacter->isReactedTo($reactant);
+        $isReacted = $reacter->hasReactedTo($reactant);
 
         $this->assertFalse($isReacted);
     }
@@ -334,7 +334,7 @@ final class ReacterTest extends TestCase
             'reactant_id' => $reactant->getId(),
         ]);
 
-        $isNotReacted = $reacter->isNotReactedTo($reactant);
+        $isNotReacted = $reacter->hasNotReactedTo($reactant);
 
         $this->assertTrue($isNotReacted);
     }
@@ -345,7 +345,7 @@ final class ReacterTest extends TestCase
         $reacter = factory(Reacter::class)->create();
         $reactant = new NullReactant(new Article());
 
-        $isNotReacted = $reacter->isNotReactedTo($reactant);
+        $isNotReacted = $reacter->hasNotReactedTo($reactant);
 
         $this->assertTrue($isNotReacted);
     }
@@ -356,7 +356,7 @@ final class ReacterTest extends TestCase
         $reacter = factory(Reacter::class)->create();
         $reactant = Reactant::query()->make();
 
-        $isNotReacted = $reacter->isNotReactedTo($reactant);
+        $isNotReacted = $reacter->hasNotReactedTo($reactant);
 
         $this->assertTrue($isNotReacted);
     }
@@ -373,7 +373,7 @@ final class ReacterTest extends TestCase
             'reactant_id' => $reactant->getId(),
         ]);
 
-        $isReacted = $reacter->isReactedToWithType($reactant, $reactionType);
+        $isReacted = $reacter->hasReactedTo($reactant, $reactionType);
 
         $this->assertTrue($isReacted);
     }
@@ -385,7 +385,7 @@ final class ReacterTest extends TestCase
         $reacter = factory(Reacter::class)->create();
         $reactant = new NullReactant(new Article());
 
-        $isReacted = $reacter->isReactedToWithType($reactant, $reactionType);
+        $isReacted = $reacter->hasReactedTo($reactant, $reactionType);
 
         $this->assertFalse($isReacted);
     }
@@ -397,7 +397,7 @@ final class ReacterTest extends TestCase
         $reacter = factory(Reacter::class)->create();
         $reactant = Reactant::query()->make();
 
-        $isReacted = $reacter->isReactedToWithType($reactant, $reactionType);
+        $isReacted = $reacter->hasReactedTo($reactant, $reactionType);
 
         $this->assertFalse($isReacted);
     }
@@ -419,7 +419,7 @@ final class ReacterTest extends TestCase
             'reactant_id' => $reactant->getId(),
         ]);
 
-        $isNotReacted = $reacter->isNotReactedToWithType($reactant, $reactionType);
+        $isNotReacted = $reacter->hasNotReactedTo($reactant, $reactionType);
 
         $this->assertTrue($isNotReacted);
     }
@@ -431,7 +431,7 @@ final class ReacterTest extends TestCase
         $reacter = factory(Reacter::class)->create();
         $reactant = new NullReactant(new Article());
 
-        $isNotReacted = $reacter->isNotReactedToWithType($reactant, $reactionType);
+        $isNotReacted = $reacter->hasNotReactedTo($reactant, $reactionType);
 
         $this->assertTrue($isNotReacted);
     }
@@ -443,7 +443,7 @@ final class ReacterTest extends TestCase
         $reacter = factory(Reacter::class)->create();
         $reactant = Reactant::query()->make();
 
-        $isNotReacted = $reacter->isNotReactedToWithType($reactant, $reactionType);
+        $isNotReacted = $reacter->hasNotReactedTo($reactant, $reactionType);
 
         $this->assertTrue($isNotReacted);
     }


### PR DESCRIPTION
Resolves #63 

### Reacter model methods

1. Replace `isReactedTo` & `isReactedToWithType` with single `hasReactedTo` method.
2. Replace `isNotReactedTo` & `isNotReactedToWithType` with single `hasNotReactedTo` method.

Before:
```php
$reacter->isReactedTo(Reactant);
$reacter->isReactedToWithType(Reactant, ReactionType);

$reacter->isNotReactedTo(Reactant);
$reacter->isNotReactedToWithType(Reactant, ReactionType);
```

After:
```php
$reacter->hasReactedTo(Reactant, ?ReactionType);
$reacter->hasNotReactedTo(Reactant, ?ReactionType);
```

### Reactant model methods

1. Replace `isReactedBy` & `isReactedByWithType` with single `isReactedBy` method.
2. Replace `isNotReactedBy` & `isNotReactedByWithType` with single `isNotReactedBy` method.

Before:

```php
$reactant->isReactedBy(Reacter);
$reactant->isReactedByWithType(Reacter, ReactionType);

$reactant->isNotReactedBy(Reacter);
$reactant->isNotReactedByWithType(Reacter, ReactionType);
```

After:

```php
$reactant->isReactedBy(Reacter, ?ReactionType);
$reactant->isNotReactedBy(Reacter, ?ReactionType);
```