### PR TITLE
Change signature of Artisan reaction-type-add command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reacter model `isNotReactedTo` & `isNotReactedToWithType` methods replaced with single `hasNotReactedTo` method
 - ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reactant model `isReactedBy`&& `isReactedByWithType` methods replaced with single `isReactedBy` method
 - ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reactant model `isNotReactedBy`&& `isNotReactedByWithType` methods replaced with single `isNotReactedBy` method
+- ([#83](https://github.com/cybercog/laravel-love/pull/83)) Artisan command `love:reaction-type-add` awaits options instead of arguments
 
 ## [7.2.1] - 2019-07-11
 

--- a/src/Console/Commands/ReactionTypeAdd.php
+++ b/src/Console/Commands/ReactionTypeAdd.php
@@ -25,9 +25,9 @@ final class ReactionTypeAdd extends Command
      * @var string
      */
     protected $signature = 'love:reaction-type-add
-                            {--default}
-                            {name?}
-                            {weight?}';
+                            {--default : Create default Like & Dislike reactions}
+                            {--name= : The name of the reaction}
+                            {--weight= : The weight of the reaction}';
 
     /**
      * The console command description.
@@ -117,14 +117,14 @@ final class ReactionTypeAdd extends Command
 
     private function resolveName(): string
     {
-        return $this->argument('name')
+        return $this->option('name')
             ?? $this->ask('How to name reaction type?')
             ?? $this->resolveName();
     }
 
     private function resolveWeight(): int
     {
-        return intval($this->argument('weight')
+        return intval($this->option('weight')
             ?? $this->ask('What is the weight of this reaction type?'));
     }
 

--- a/tests/Unit/Console/Commands/ReactionTypeAddTest.php
+++ b/tests/Unit/Console/Commands/ReactionTypeAddTest.php
@@ -85,8 +85,8 @@ final class ReactionTypeAddTest extends TestCase
         $this->disableMocking();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', [
-            'name' => 'TestName',
-            'weight' => 4,
+            '--name' => 'TestName',
+            '--weight' => 4,
         ]);
 
         $this->assertSame(0, $status);
@@ -101,8 +101,8 @@ final class ReactionTypeAddTest extends TestCase
         $this->disableMocking();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', [
-            'name' => 'test-name',
-            'weight' => 4,
+            '--name' => 'test-name',
+            '--weight' => 4,
         ]);
 
         $this->assertSame(0, $status);
@@ -119,7 +119,7 @@ final class ReactionTypeAddTest extends TestCase
         ]);
         $typesCount = ReactionType::query()->count();
         $this
-            ->artisan('love:reaction-type-add', ['name' => 'TestName'])
+            ->artisan('love:reaction-type-add', ['--name' => 'TestName'])
             ->expectsOutput('Reaction type with name `TestName` already exists.')
             ->assertExitCode(1);
 
@@ -134,7 +134,7 @@ final class ReactionTypeAddTest extends TestCase
         ]);
         $typesCount = ReactionType::query()->count();
         $this
-            ->artisan('love:reaction-type-add', ['name' => 'test-name'])
+            ->artisan('love:reaction-type-add', ['--name' => 'test-name'])
             ->expectsOutput('Reaction type with name `TestName` already exists.')
             ->assertExitCode(1);
 
@@ -147,8 +147,8 @@ final class ReactionTypeAddTest extends TestCase
         $this->disableMocking();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', [
-            'name' => 'TestName',
-            'weight' => -4,
+            '--name' => 'TestName',
+            '--weight' => -4,
         ]);
 
         $this->assertSame(0, $status);
@@ -163,8 +163,8 @@ final class ReactionTypeAddTest extends TestCase
         $this->disableMocking();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', [
-            'name' => 'TestName',
-            'weight' => 4,
+            '--name' => 'TestName',
+            '--weight' => 4,
         ]);
 
         $this->assertSame(0, $status);
@@ -188,7 +188,7 @@ final class ReactionTypeAddTest extends TestCase
     {
         $typesCount = ReactionType::query()->count();
         $this
-            ->artisan('love:reaction-type-add', ['weight' => '4'])
+            ->artisan('love:reaction-type-add', ['--weight' => '4'])
             ->expectsQuestion('How to name reaction type?', 'TestName')
             ->assertExitCode(0);
 
@@ -202,7 +202,7 @@ final class ReactionTypeAddTest extends TestCase
     {
         $typesCount = ReactionType::query()->count();
         $this
-            ->artisan('love:reaction-type-add', ['weight' => '4'])
+            ->artisan('love:reaction-type-add', ['--weight' => '4'])
             ->expectsQuestion('How to name reaction type?', null)
             ->expectsQuestion('How to name reaction type?', 'TestName')
             ->assertExitCode(0);
@@ -217,7 +217,7 @@ final class ReactionTypeAddTest extends TestCase
     {
         $typesCount = ReactionType::query()->count();
         $this
-            ->artisan('love:reaction-type-add', ['weight' => '4'])
+            ->artisan('love:reaction-type-add', ['--weight' => '4'])
             ->expectsQuestion('How to name reaction type?', '  ')
             ->expectsOutput('Reaction type with name `` is invalid.')
             ->assertExitCode(1);
@@ -230,7 +230,7 @@ final class ReactionTypeAddTest extends TestCase
     {
         $typesCount = ReactionType::query()->count();
         $this
-            ->artisan('love:reaction-type-add', ['name' => 'TestName'])
+            ->artisan('love:reaction-type-add', ['--name' => 'TestName'])
             ->expectsQuestion('What is the weight of this reaction type?', '4')
             ->assertExitCode(0);
 
@@ -244,7 +244,7 @@ final class ReactionTypeAddTest extends TestCase
     {
         $typesCount = ReactionType::query()->count();
         $this
-            ->artisan('love:reaction-type-add', ['name' => 'TestName'])
+            ->artisan('love:reaction-type-add', ['--name' => 'TestName'])
             ->expectsQuestion('What is the weight of this reaction type?', null)
             ->assertExitCode(0);
 
@@ -257,7 +257,7 @@ final class ReactionTypeAddTest extends TestCase
     public function it_has_valid_output_after_type_add(): void
     {
         $this
-            ->artisan('love:reaction-type-add', ['name' => 'TestName'])
+            ->artisan('love:reaction-type-add', ['--name' => 'TestName'])
             ->expectsQuestion('What is the weight of this reaction type?', 4)
             ->expectsOutput('Reaction type with name `TestName` and weight `4` was added.')
             ->assertExitCode(0);


### PR DESCRIPTION
Resolves #82 

This command will create `Like` type with weight equal to `1`:
```sh
php artisan love:reaction-type-add --name=Like --weight=1
```

This command is similar to command above:
```sh
php artisan love:reaction-type-add --weight=1 --name=Like
```

This command will interactively ask for `name` and after it will create type with weight equal to `1`:
```sh
php artisan love:reaction-type-add --weight=1
```

This command will interactively ask for `weight` and after it will create type with name equal to `Like`:
```sh
php artisan love:reaction-type-add --name=Like
```