### PR TITLE
Add reaction power

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,14 +47,14 @@
     },
     "require": {
         "php": "^7.1.3",
-        "illuminate/database": "5.6.*|5.7.*|5.8.*",
-        "illuminate/support": "5.6.*|5.7.*|5.8.*"
+        "illuminate/database": "5.7.*|5.8.*",
+        "illuminate/support": "5.7.*|5.8.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",
         "mockery/mockery": "^1.0",
-        "orchestra/database": "~3.6.0|~3.7.0|~3.8.0",
-        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0",
+        "orchestra/database": "~3.7.0|~3.8.0",
+        "orchestra/testbench": "~3.7.0|~3.8.0",
         "phpunit/phpunit": "^7.5"
     },
     "autoload": {

--- a/contracts/Reacter/Models/Reacter.php
+++ b/contracts/Reacter/Models/Reacter.php
@@ -28,7 +28,7 @@ interface Reacter
      */
     public function getReactions(): iterable;
 
-    public function reactTo(Reactant $reactant, ReactionType $reactionType): void;
+    public function reactTo(Reactant $reactant, ReactionType $reactionType, ?int $power = null): void;
 
     public function unreactTo(Reactant $reactant, ReactionType $reactionType): void;
 

--- a/contracts/Reaction/Models/Reaction.php
+++ b/contracts/Reaction/Models/Reaction.php
@@ -29,6 +29,8 @@ interface Reaction
 
     public function getWeight(): int;
 
+    public function getPower(): int;
+
     public function isOfType(ReactionType $type): bool;
 
     public function isNotOfType(ReactionType $type): bool;

--- a/database/migrations/2018_07_22_002000_create_love_reactions_table.php
+++ b/database/migrations/2018_07_22_002000_create_love_reactions_table.php
@@ -29,6 +29,7 @@ final class CreateLoveReactionsTable extends Migration
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('reacter_id');
             $table->unsignedBigInteger('reaction_type_id');
+            $table->unsignedTinyInteger('power')->default(1);
             $table->timestamps();
 
             $table->index([

--- a/database/migrations/2018_07_22_002000_create_love_reactions_table.php
+++ b/database/migrations/2018_07_22_002000_create_love_reactions_table.php
@@ -29,7 +29,7 @@ final class CreateLoveReactionsTable extends Migration
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('reacter_id');
             $table->unsignedBigInteger('reaction_type_id');
-            $table->unsignedTinyInteger('power')->default(1);
+            $table->unsignedTinyInteger('power');
             $table->timestamps();
 
             $table->index([

--- a/src/Reacter/Models/NullReacter.php
+++ b/src/Reacter/Models/NullReacter.php
@@ -49,7 +49,8 @@ final class NullReacter implements
 
     public function reactTo(
         Reactant $reactant,
-        ReactionType $reactionType
+        ReactionType $reactionType,
+        ?int $power = null
     ): void {
         throw ReacterInvalid::notExists();
     }

--- a/src/Reacter/Models/Reacter.php
+++ b/src/Reacter/Models/Reacter.php
@@ -72,7 +72,8 @@ final class Reacter extends Model implements
 
     public function reactTo(
         ReactantContract $reactant,
-        ReactionTypeContract $reactionType
+        ReactionTypeContract $reactionType,
+        ?int $power = null
     ): void {
         if ($reactant->isNull()) {
             throw ReactantInvalid::notExists();
@@ -87,6 +88,7 @@ final class Reacter extends Model implements
         $this->reactions()->create([
             'reaction_type_id' => $reactionType->getId(),
             'reactant_id' => $reactant->getId(),
+            'power' => $power,
         ]);
     }
 

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -77,6 +77,11 @@ final class Reaction extends Model implements
         return $this->getType()->getWeight();
     }
 
+    public function getPower(): int
+    {
+        return $this->getAttributeValue('power');
+    }
+
     public function isOfType(
         ReactionTypeContract $reactionType
     ): bool {

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -28,6 +28,10 @@ final class Reaction extends Model implements
 {
     protected $table = 'love_reactions';
 
+    protected $attributes = [
+        'power' => 1,
+    ];
+
     protected $fillable = [
         'reactant_id',
         'reaction_type_id',
@@ -35,6 +39,7 @@ final class Reaction extends Model implements
 
     protected $casts = [
         'id' => 'string',
+        'power' => 'integer',
     ];
 
     public function reactant(): BelongsTo
@@ -74,7 +79,7 @@ final class Reaction extends Model implements
 
     public function getWeight(): int
     {
-        return $this->getType()->getWeight();
+        return $this->getType()->getWeight() * $this->getPower();
     }
 
     public function getPower(): int

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -26,10 +26,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 final class Reaction extends Model implements
     ReactionContract
 {
+    const DEFAULT_POWER = 1;
+
     protected $table = 'love_reactions';
 
     protected $attributes = [
-        'power' => 1,
+        'power' => self::DEFAULT_POWER,
     ];
 
     protected $fillable = [

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -35,6 +35,7 @@ final class Reaction extends Model implements
     protected $fillable = [
         'reactant_id',
         'reaction_type_id',
+        'power',
     ];
 
     protected $casts = [

--- a/src/Reaction/Observers/ReactionObserver.php
+++ b/src/Reaction/Observers/ReactionObserver.php
@@ -19,6 +19,14 @@ use Cog\Laravel\Love\Reaction\Models\Reaction;
 
 final class ReactionObserver
 {
+    public function creating(
+        Reaction $reaction
+    ): void {
+        if ($reaction->isDirty('power') && is_null($reaction->getAttributeValue('power'))) {
+            $reaction->setAttribute('power', 1);
+        }
+    }
+
     public function created(
         Reaction $reaction
     ): void {

--- a/src/Reaction/Observers/ReactionObserver.php
+++ b/src/Reaction/Observers/ReactionObserver.php
@@ -23,7 +23,7 @@ final class ReactionObserver
         Reaction $reaction
     ): void {
         if ($reaction->isDirty('power') && is_null($reaction->getAttributeValue('power'))) {
-            $reaction->setAttribute('power', 1);
+            $reaction->setAttribute('power', Reaction::DEFAULT_POWER);
         }
     }
 

--- a/tests/Unit/Console/Commands/ReactionTypeAddTest.php
+++ b/tests/Unit/Console/Commands/ReactionTypeAddTest.php
@@ -15,14 +15,13 @@ namespace Cog\Tests\Laravel\Love\Unit\Console\Commands;
 
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Tests\Laravel\Love\TestCase;
-use Illuminate\Support\Str;
 
 final class ReactionTypeAddTest extends TestCase
 {
     /** @test */
     public function it_creates_only_two_default_types(): void
     {
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', ['--default' => true]);
 
@@ -261,12 +260,5 @@ final class ReactionTypeAddTest extends TestCase
             ->expectsQuestion('What is the weight of this reaction type?', 4)
             ->expectsOutput('Reaction type with name `TestName` and weight `4` was added.')
             ->assertExitCode(0);
-    }
-
-    private function disableMocking(): void
-    {
-        if (!Str::startsWith($this->app->version(), '5.6')) {
-            $this->withoutMockingConsoleOutput();
-        }
     }
 }

--- a/tests/Unit/Console/Commands/ReactionTypeAddTest.php
+++ b/tests/Unit/Console/Commands/ReactionTypeAddTest.php
@@ -32,7 +32,7 @@ final class ReactionTypeAddTest extends TestCase
     /** @test */
     public function it_can_create_default_like_and_dislike_types(): void
     {
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
         $likeNotExistInitially = ReactionType::query()->where('name', 'Like')->doesntExist();
         $dislikeNotExistInitially = ReactionType::query()->where('name', 'Dislike')->doesntExist();
         $status = $this->artisan('love:reaction-type-add', ['--default' => true]);
@@ -81,7 +81,7 @@ final class ReactionTypeAddTest extends TestCase
     /** @test */
     public function it_can_create_type_with_name_argument(): void
     {
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', [
             '--name' => 'TestName',
@@ -97,7 +97,7 @@ final class ReactionTypeAddTest extends TestCase
     /** @test */
     public function it_convert_type_name_to_studly_case(): void
     {
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', [
             '--name' => 'test-name',
@@ -143,7 +143,7 @@ final class ReactionTypeAddTest extends TestCase
     /** @test */
     public function it_can_create_type_with_weight_argument(): void
     {
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', [
             '--name' => 'TestName',
@@ -159,7 +159,7 @@ final class ReactionTypeAddTest extends TestCase
     /** @test */
     public function it_not_creates_default_types_without_default_option(): void
     {
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', [
             '--name' => 'TestName',

--- a/tests/Unit/Console/Commands/RecountTest.php
+++ b/tests/Unit/Console/Commands/RecountTest.php
@@ -26,7 +26,6 @@ use Cog\Tests\Laravel\Love\Stubs\Models\Bot;
 use Cog\Tests\Laravel\Love\Stubs\Models\Entity;
 use Cog\Tests\Laravel\Love\Stubs\Models\EntityWithMorphMap;
 use Cog\Tests\Laravel\Love\TestCase;
-use Illuminate\Support\Str;
 
 final class RecountTest extends TestCase
 {
@@ -38,9 +37,7 @@ final class RecountTest extends TestCase
     {
         parent::setUp();
 
-        if (!Str::startsWith($this->app->version(), '5.6')) {
-            $this->withoutMockingConsoleOutput();
-        }
+        $this->withoutMockingConsoleOutput();
 
         $this->likeType = factory(ReactionType::class)->create([
             'name' => 'Like',

--- a/tests/Unit/Console/Commands/SetupReactableTest.php
+++ b/tests/Unit/Console/Commands/SetupReactableTest.php
@@ -27,7 +27,7 @@ final class SetupReactableTest extends TestCase
     {
         parent::setUp();
 
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
     }
 
     public function tearDown(): void
@@ -108,13 +108,6 @@ final class SetupReactableTest extends TestCase
         $this->assertSame(1, $status);
         $this->assertFalse(class_exists('AddLoveReactantIdToArticlesTable'));
         $this->assertFalse($this->isMigrationFileExists('add_love_reactant_id_to_articles_table'));
-    }
-
-    private function disableMocking(): void
-    {
-        if (!Str::startsWith($this->app->version(), '5.6')) {
-            $this->withoutMockingConsoleOutput();
-        }
     }
 
     private function isMigrationFileExists(string $filename): bool

--- a/tests/Unit/Console/Commands/SetupReacterableTest.php
+++ b/tests/Unit/Console/Commands/SetupReacterableTest.php
@@ -27,7 +27,7 @@ final class SetupReacterableTest extends TestCase
     {
         parent::setUp();
 
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
     }
 
     public function tearDown(): void
@@ -107,13 +107,6 @@ final class SetupReacterableTest extends TestCase
 
         $this->assertSame(1, $status);
         $this->assertFalse($this->isMigrationFileExists('add_love_reacter_id_to_users_table'));
-    }
-
-    private function disableMocking(): void
-    {
-        if (!Str::startsWith($this->app->version(), '5.6')) {
-            $this->withoutMockingConsoleOutput();
-        }
     }
 
     private function isMigrationFileExists(string $filename): bool

--- a/tests/Unit/Reacter/Models/NullReacterTest.php
+++ b/tests/Unit/Reacter/Models/NullReacterTest.php
@@ -96,6 +96,19 @@ final class NullReacterTest extends TestCase
     }
 
     /** @test */
+    public function it_throws_reactant_invalid_on_react_to_with_power(): void
+    {
+        $this->expectException(ReacterInvalid::class);
+
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = new NullReacter(new Bot());
+        $reactable = factory(Article::class)->create();
+        $reactant = $reactable->loveReactant;
+
+        $reacter->reactTo($reactant, $reactionType, 4);
+    }
+
+    /** @test */
     public function it_throws_reactant_invalid_on_unreact_to(): void
     {
         $this->expectException(ReacterInvalid::class);

--- a/tests/Unit/Reacter/Models/ReacterTest.php
+++ b/tests/Unit/Reacter/Models/ReacterTest.php
@@ -249,6 +249,65 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
+    public function it_can_react_to_reactant_with_power_when_already_reacted_but_power_differs(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactable = factory(Article::class)->create();
+        $reactant = $reactable->loveReactant;
+        factory(Reaction::class)->create([
+            'reactant_id' => $reactant->getId(),
+            'reacter_id' => $reacter->getId(),
+            'reaction_type_id' => $reactionType->getId(),
+            'power' => 2,
+        ]);
+
+        $reacter->reactTo($reactant, $reactionType, 4);
+
+        $this->assertCount(1, $reacter->reactions);
+        $assertReaction = $reacter->reactions->first();
+        $this->assertSame(4, $assertReaction->getAttribute('power'));
+    }
+
+    /** @test */
+    public function it_throws_exception_on_react_to_reactant_with_power_when_already_reacted_and_power_is_same(): void
+    {
+        $this->expectException(ReactionAlreadyExists::class);
+
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactable = factory(Article::class)->create();
+        $reactant = $reactable->loveReactant;
+        factory(Reaction::class)->create([
+            'reactant_id' => $reactant->getId(),
+            'reacter_id' => $reacter->getId(),
+            'reaction_type_id' => $reactionType->getId(),
+            'power' => 2,
+        ]);
+
+        $reacter->reactTo($reactant, $reactionType, 2);
+    }
+
+    /** @test */
+    public function it_throws_exception_on_react_to_reactant_with_power_when_already_reacted_and_power_is_null(): void
+    {
+        $this->expectException(ReactionAlreadyExists::class);
+
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactable = factory(Article::class)->create();
+        $reactant = $reactable->loveReactant;
+        factory(Reaction::class)->create([
+            'reactant_id' => $reactant->getId(),
+            'reacter_id' => $reacter->getId(),
+            'reaction_type_id' => $reactionType->getId(),
+            'power' => 2,
+        ]);
+
+        $reacter->reactTo($reactant, $reactionType, null);
+    }
+
+    /** @test */
     public function it_can_unreact_to_reactant(): void
     {
         $reactionType = factory(ReactionType::class)->create();

--- a/tests/Unit/Reacter/Models/ReacterTest.php
+++ b/tests/Unit/Reacter/Models/ReacterTest.php
@@ -219,6 +219,36 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
+    public function it_can_react_to_reactant_with_power(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactable = factory(Article::class)->create();
+        $reactant = $reactable->loveReactant;
+
+        $reacter->reactTo($reactant, $reactionType, 4);
+
+        $this->assertCount(1, $reacter->reactions);
+        $assertReaction = $reacter->reactions->first();
+        $this->assertSame(4, $assertReaction->getAttribute('power'));
+    }
+
+    /** @test */
+    public function it_can_react_to_reactant_with_power_when_power_is_null(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactable = factory(Article::class)->create();
+        $reactant = $reactable->loveReactant;
+
+        $reacter->reactTo($reactant, $reactionType, null);
+
+        $this->assertCount(1, $reacter->reactions);
+        $assertReaction = $reacter->reactions->first();
+        $this->assertSame(1, $assertReaction->getAttribute('power'));
+    }
+
+    /** @test */
     public function it_can_unreact_to_reactant(): void
     {
         $reactionType = factory(ReactionType::class)->create();

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -240,7 +240,7 @@ final class ReactionTest extends TestCase
     {
         $reaction = new Reaction();
 
-        $this->assertSame(1, $reaction->getPower());
+        $this->assertSame(Reaction::DEFAULT_POWER, $reaction->getPower());
     }
 
     /** @test */

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -58,6 +58,16 @@ final class ReactionTest extends TestCase
     }
 
     /** @test */
+    public function it_casts_power_to_integer(): void
+    {
+        $reaction = factory(Reaction::class)->make([
+            'power' => '4',
+        ]);
+
+        $this->assertSame(4, $reaction->getAttribute('power'));
+    }
+
+    /** @test */
     public function it_can_belong_to_type(): void
     {
         $type = factory(ReactionType::class)->create();
@@ -213,6 +223,30 @@ final class ReactionTest extends TestCase
         ]);
 
         $this->assertSame(2, $reaction->getPower());
+    }
+
+    /** @test */
+    public function it_can_get_default_power_when_power_is_null(): void
+    {
+        $reaction = new Reaction();
+
+        $this->assertSame(1, $reaction->getPower());
+    }
+
+    /** @test */
+    public function it_can_get_weight_affected_by_power(): void
+    {
+        $reactionType = factory(ReactionType::class)->create([
+            'weight' => 4,
+        ]);
+
+        /** @var \Cog\Laravel\Love\Reaction\Models\Reaction $reaction */
+        $reaction = factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'power' => 2,
+        ]);
+
+        $this->assertSame(8, $reaction->getWeight());
     }
 
     /** @test */

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -28,6 +28,16 @@ use TypeError;
 final class ReactionTest extends TestCase
 {
     /** @test */
+    public function it_can_fill_reactant_id(): void
+    {
+        $reaction = new Reaction([
+            'reactant_id' => 4,
+        ]);
+
+        $this->assertSame(4, $reaction->getAttribute('reactant_id'));
+    }
+
+    /** @test */
     public function it_can_fill_reaction_type_id(): void
     {
         $reaction = new Reaction([
@@ -38,13 +48,13 @@ final class ReactionTest extends TestCase
     }
 
     /** @test */
-    public function it_can_fill_reactant_id(): void
+    public function it_can_fill_power(): void
     {
         $reaction = new Reaction([
-            'reactant_id' => 4,
+            'power' => 4,
         ]);
 
-        $this->assertSame(4, $reaction->getAttribute('reactant_id'));
+        $this->assertSame(4, $reaction->getAttribute('power'));
     }
 
     /** @test */

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -205,6 +205,17 @@ final class ReactionTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_power(): void
+    {
+        /** @var \Cog\Laravel\Love\Reaction\Models\Reaction $reaction */
+        $reaction = factory(Reaction::class)->create([
+            'power' => 2,
+        ]);
+
+        $this->assertSame(2, $reaction->getPower());
+    }
+
+    /** @test */
     public function it_can_check_if_reaction_is_of_type(): void
     {
         $reactionType1 = factory(ReactionType::class)->create();

--- a/tests/Unit/Reaction/Observers/ReactionObserverTest.php
+++ b/tests/Unit/Reaction/Observers/ReactionObserverTest.php
@@ -22,6 +22,16 @@ use Cog\Tests\Laravel\Love\TestCase;
 final class ReactionObserverTest extends TestCase
 {
     /** @test */
+    public function it_creates_reaction_with_default_power_when_power_value_is_null(): void
+    {
+        $reaction = factory(Reaction::class)->create([
+            'power' => null,
+        ]);
+
+        $this->assertSame(1, $reaction->getAttribute('power'));
+    }
+
+    /** @test */
     public function it_creates_counter_on_reaction_created_when_counter_not_exists(): void
     {
         $reactionType = factory(ReactionType::class)->create([

--- a/tests/database/factories/ReactionFactory.php
+++ b/tests/database/factories/ReactionFactory.php
@@ -23,5 +23,6 @@ $factory->define(Reaction::class, function (Faker $faker) {
         'reaction_type_id' => factory(ReactionType::class),
         'reactant_id' => factory(Reactant::class),
         'reacter_id' => factory(Reacter::class),
+        'power' => 1,
     ];
 });


### PR DESCRIPTION
Resolves #26 

- Laravel 5.6 support dropped

This has happened because default model attribute values were introduced in v5.7 & because [v5.6 has reached end of life in February 7th, 2019](https://laravel.com/docs/master/releases). 