### PR TITLE
Drop Laravel 5.6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reactant model `isNotReactedBy`&& `isNotReactedByWithType` methods replaced with single `isNotReactedBy` method
 - ([#83](https://github.com/cybercog/laravel-love/pull/83)) Artisan command `love:reaction-type-add` awaits options instead of arguments
 
+### Removed
+
+- ([#86](https://github.com/cybercog/laravel-love/pull/86)) Laravel 5.6 support obsolete
+
 ## [7.2.1] - 2019-07-11
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -47,14 +47,14 @@
     },
     "require": {
         "php": "^7.1.3",
-        "illuminate/database": "5.6.*|5.7.*|5.8.*",
-        "illuminate/support": "5.6.*|5.7.*|5.8.*"
+        "illuminate/database": "5.7.*|5.8.*",
+        "illuminate/support": "5.7.*|5.8.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",
         "mockery/mockery": "^1.0",
-        "orchestra/database": "~3.6.0|~3.7.0|~3.8.0",
-        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0",
+        "orchestra/database": "~3.7.0|~3.8.0",
+        "orchestra/testbench": "~3.7.0|~3.8.0",
         "phpunit/phpunit": "^7.5"
     },
     "autoload": {

--- a/tests/Unit/Console/Commands/ReactionTypeAddTest.php
+++ b/tests/Unit/Console/Commands/ReactionTypeAddTest.php
@@ -15,14 +15,13 @@ namespace Cog\Tests\Laravel\Love\Unit\Console\Commands;
 
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Tests\Laravel\Love\TestCase;
-use Illuminate\Support\Str;
 
 final class ReactionTypeAddTest extends TestCase
 {
     /** @test */
     public function it_creates_only_two_default_types(): void
     {
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', ['--default' => true]);
 
@@ -33,7 +32,7 @@ final class ReactionTypeAddTest extends TestCase
     /** @test */
     public function it_can_create_default_like_and_dislike_types(): void
     {
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
         $likeNotExistInitially = ReactionType::query()->where('name', 'Like')->doesntExist();
         $dislikeNotExistInitially = ReactionType::query()->where('name', 'Dislike')->doesntExist();
         $status = $this->artisan('love:reaction-type-add', ['--default' => true]);
@@ -82,7 +81,7 @@ final class ReactionTypeAddTest extends TestCase
     /** @test */
     public function it_can_create_type_with_name_argument(): void
     {
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', [
             '--name' => 'TestName',
@@ -98,7 +97,7 @@ final class ReactionTypeAddTest extends TestCase
     /** @test */
     public function it_convert_type_name_to_studly_case(): void
     {
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', [
             '--name' => 'test-name',
@@ -144,7 +143,7 @@ final class ReactionTypeAddTest extends TestCase
     /** @test */
     public function it_can_create_type_with_weight_argument(): void
     {
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', [
             '--name' => 'TestName',
@@ -160,7 +159,7 @@ final class ReactionTypeAddTest extends TestCase
     /** @test */
     public function it_not_creates_default_types_without_default_option(): void
     {
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
         $typesCount = ReactionType::query()->count();
         $status = $this->artisan('love:reaction-type-add', [
             '--name' => 'TestName',
@@ -261,12 +260,5 @@ final class ReactionTypeAddTest extends TestCase
             ->expectsQuestion('What is the weight of this reaction type?', 4)
             ->expectsOutput('Reaction type with name `TestName` and weight `4` was added.')
             ->assertExitCode(0);
-    }
-
-    private function disableMocking(): void
-    {
-        if (!Str::startsWith($this->app->version(), '5.6')) {
-            $this->withoutMockingConsoleOutput();
-        }
     }
 }

--- a/tests/Unit/Console/Commands/RecountTest.php
+++ b/tests/Unit/Console/Commands/RecountTest.php
@@ -26,7 +26,6 @@ use Cog\Tests\Laravel\Love\Stubs\Models\Bot;
 use Cog\Tests\Laravel\Love\Stubs\Models\Entity;
 use Cog\Tests\Laravel\Love\Stubs\Models\EntityWithMorphMap;
 use Cog\Tests\Laravel\Love\TestCase;
-use Illuminate\Support\Str;
 
 final class RecountTest extends TestCase
 {
@@ -38,9 +37,7 @@ final class RecountTest extends TestCase
     {
         parent::setUp();
 
-        if (!Str::startsWith($this->app->version(), '5.6')) {
-            $this->withoutMockingConsoleOutput();
-        }
+        $this->withoutMockingConsoleOutput();
 
         $this->likeType = factory(ReactionType::class)->create([
             'name' => 'Like',

--- a/tests/Unit/Console/Commands/SetupReactableTest.php
+++ b/tests/Unit/Console/Commands/SetupReactableTest.php
@@ -27,7 +27,7 @@ final class SetupReactableTest extends TestCase
     {
         parent::setUp();
 
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
     }
 
     public function tearDown(): void
@@ -108,13 +108,6 @@ final class SetupReactableTest extends TestCase
         $this->assertSame(1, $status);
         $this->assertFalse(class_exists('AddLoveReactantIdToArticlesTable'));
         $this->assertFalse($this->isMigrationFileExists('add_love_reactant_id_to_articles_table'));
-    }
-
-    private function disableMocking(): void
-    {
-        if (!Str::startsWith($this->app->version(), '5.6')) {
-            $this->withoutMockingConsoleOutput();
-        }
     }
 
     private function isMigrationFileExists(string $filename): bool

--- a/tests/Unit/Console/Commands/SetupReacterableTest.php
+++ b/tests/Unit/Console/Commands/SetupReacterableTest.php
@@ -27,7 +27,7 @@ final class SetupReacterableTest extends TestCase
     {
         parent::setUp();
 
-        $this->disableMocking();
+        $this->withoutMockingConsoleOutput();
     }
 
     public function tearDown(): void
@@ -107,13 +107,6 @@ final class SetupReacterableTest extends TestCase
 
         $this->assertSame(1, $status);
         $this->assertFalse($this->isMigrationFileExists('add_love_reacter_id_to_users_table'));
-    }
-
-    private function disableMocking(): void
-    {
-        if (!Str::startsWith($this->app->version(), '5.6')) {
-            $this->withoutMockingConsoleOutput();
-        }
     }
 
     private function isMigrationFileExists(string $filename): bool


### PR DESCRIPTION
Laravel 5.6 has reached End of Life. Dropping it's support to start using default attribute values introduced in Laravel 5.7.