### PR TITLE
Merge whereReactedByWithType method to whereReactedBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#83](https://github.com/cybercog/laravel-love/pull/83)) Artisan command `love:reaction-type-add` awaits options instead of arguments
 - ([#87](https://github.com/cybercog/laravel-love/pull/87)) Resolving default attributes values moved from accessors to Eloquent
 - ([#88](https://github.com/cybercog/laravel-love/pull/88)) ReactionType attribute `weight` renamed to `mass`
-- ([#88](https://github.com/cybercog/laravel-love/pull/88)) ReactionType method `getWeight` renamed to `getMass`
+- ([#89](https://github.com/cybercog/laravel-love/pull/89)) Reactable method `scopeWhereReactedByWithType` merged with `scopeWhereReactedBy`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#83](https://github.com/cybercog/laravel-love/pull/83)) Artisan command `love:reaction-type-add` awaits options instead of arguments
 - ([#87](https://github.com/cybercog/laravel-love/pull/87)) Resolving default attributes values moved from accessors to Eloquent
 - ([#88](https://github.com/cybercog/laravel-love/pull/88)) ReactionType attribute `weight` renamed to `mass`
+- ([#88](https://github.com/cybercog/laravel-love/pull/88)) ReactionType method `getWeight` renamed to `getMass`
 - ([#89](https://github.com/cybercog/laravel-love/pull/89)) Reactable method `scopeWhereReactedByWithType` merged with `scopeWhereReactedBy`
 
 ### Removed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,6 +15,7 @@
 - Find all `isReactedByWithType` method usages and replace it with `isReactedBy`
 - Find all `isNotReactedByWithType` method usages and replace it with `isNotReactedBy`
 - The `ReactionType` method `getWeight` was renamed to `getMass`. If you're using your own implementation of `ReactionType`, please update the method name.
+- Find all `whereReactedByWithType` method usages and replace it with `whereReactedBy`
 
 ### Database migration
 

--- a/src/Reactable/Models/Traits/Reactable.php
+++ b/src/Reactable/Models/Traits/Reactable.php
@@ -81,21 +81,14 @@ trait Reactable
 
     public function scopeWhereReactedBy(
         Builder $query,
-        ReacterContract $reacter
-    ): Builder {
-        return $query->whereHas('loveReactant.reactions', function (Builder $reactionsQuery) use ($reacter) {
-            $reactionsQuery->where('reacter_id', $reacter->getId());
-        });
-    }
-
-    public function scopeWhereReactedByWithType(
-        Builder $query,
         ReacterContract $reacter,
-        ReactionTypeContract $reactionType
+        ?ReactionTypeContract $reactionType = null
     ): Builder {
         return $query->whereHas('loveReactant.reactions', function (Builder $reactionsQuery) use ($reacter, $reactionType) {
             $reactionsQuery->where('reacter_id', $reacter->getId());
-            $reactionsQuery->where('reaction_type_id', $reactionType->getId());
+            if (!is_null($reactionType)) {
+                $reactionsQuery->where('reaction_type_id', $reactionType->getId());
+            }
         });
     }
 

--- a/tests/Unit/Reactable/Models/Traits/ReactableTest.php
+++ b/tests/Unit/Reactable/Models/Traits/ReactableTest.php
@@ -260,16 +260,16 @@ final class ReactableTest extends TestCase
         ]);
 
         $reactedByReacter1WithReactionType1 = Article::query()
-            ->whereReactedByWithType($reacter1, $reactionType1)
+            ->whereReactedBy($reacter1, $reactionType1)
             ->get();
         $reactedByReacter1WithReactionType2 = Article::query()
-            ->whereReactedByWithType($reacter1, $reactionType2)
+            ->whereReactedBy($reacter1, $reactionType2)
             ->get();
         $reactedByReacter2WithReactionType1 = Article::query()
-            ->whereReactedByWithType($reacter2, $reactionType1)
+            ->whereReactedBy($reacter2, $reactionType1)
             ->get();
         $reactedByReacter2WithReactionType2 = Article::query()
-            ->whereReactedByWithType($reacter2, $reactionType2)
+            ->whereReactedBy($reacter2, $reactionType2)
             ->get();
 
         $this->assertSame([


### PR DESCRIPTION
### Reactable model methods

Replace `scopeWhereReactedBy` & `scopeWhereReactedByWithType` with single `scopeWhereReactedBy` method.

Before:
```php
Comment::whereReactedBy(Reactant);
Comment::whereReactedByWithType(Reactant, ReactionType);
```

After:
```php
Comment::whereReactedBy(Reactant, ?ReactionType);
```