### PR TITLE
Move counters default attributes values to application level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#88](https://github.com/cybercog/laravel-love/pull/88)) ReactionType attribute `weight` renamed to `mass`
 - ([#88](https://github.com/cybercog/laravel-love/pull/88)) ReactionType method `getWeight` renamed to `getMass`
 - ([#89](https://github.com/cybercog/laravel-love/pull/89)) Reactable method `scopeWhereReactedByWithType` merged with `scopeWhereReactedBy`
+- ([#90](https://github.com/cybercog/laravel-love/pull/90)) ReactionCounter attributes `count` & `weight` default values moved to application level
+- ([#90](https://github.com/cybercog/laravel-love/pull/90)) ReactionTotal attributes `count` & `weight` default values moved to application level
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- ([#90](https://github.com/cybercog/laravel-love/pull/90)) Added `ReactionCounter::DEFAULT_COUNT` & `ReactionCounter::DEFAULT_WEIGHT` constants
+- ([#90](https://github.com/cybercog/laravel-love/pull/90)) Added `ReactionTotal::DEFAULT_COUNT` & `ReactionTotal::DEFAULT_WEIGHT` constants
+
 ### Changed
 
 - ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reacter model `isReactedTo` & `isReactedToWithType` methods replaced with single `hasReactedTo` method

--- a/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
+++ b/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
@@ -28,7 +28,7 @@ final class CreateLoveReactantReactionCountersTable extends Migration
             $table->bigIncrements('id');
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('reaction_type_id');
-            $table->unsignedBigInteger('count')->default(0);
+            $table->unsignedBigInteger('count');
             $table->bigInteger('weight')->default(0);
             $table->timestamps();
 

--- a/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
+++ b/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
@@ -29,7 +29,7 @@ final class CreateLoveReactantReactionCountersTable extends Migration
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('reaction_type_id');
             $table->unsignedBigInteger('count');
-            $table->bigInteger('weight')->default(0);
+            $table->bigInteger('weight');
             $table->timestamps();
 
             $table->index([

--- a/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
+++ b/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
@@ -27,8 +27,8 @@ final class CreateLoveReactantReactionTotalsTable extends Migration
         Schema::create('love_reactant_reaction_totals', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('reactant_id');
-            $table->unsignedBigInteger('count')->default(0);
-            $table->bigInteger('weight')->default(0);
+            $table->unsignedBigInteger('count');
+            $table->bigInteger('weight');
             $table->timestamps();
 
             $table

--- a/src/Console/Commands/UpgradeV7ToV8.php
+++ b/src/Console/Commands/UpgradeV7ToV8.php
@@ -43,6 +43,10 @@ final class UpgradeV7ToV8 extends Command
     public function handle(): void
     {
         $this->dbChangeReactionType();
+        // TODO: Remove `reaction_counters.count` default value
+        // TODO: Remove `reaction_counters.weight` default value
+        // TODO: Remove `reaction_totals.count` default value
+        // TODO: Remove `reaction_totals.weight` default value
     }
 
     private function dbChangeReactionType(): void

--- a/src/LoveServiceProvider.php
+++ b/src/LoveServiceProvider.php
@@ -22,6 +22,8 @@ use Cog\Laravel\Love\Reactant\Listeners\DecrementAggregates;
 use Cog\Laravel\Love\Reactant\Listeners\IncrementAggregates;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Observers\ReactionCounterObserver;
+use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
+use Cog\Laravel\Love\Reactant\ReactionTotal\Observers\ReactionTotalObserver;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenAdded;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenRemoved;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
@@ -75,6 +77,7 @@ final class LoveServiceProvider extends ServiceProvider
     {
         Reaction::observe(ReactionObserver::class);
         ReactionCounter::observe(ReactionCounterObserver::class);
+        ReactionTotal::observe(ReactionTotalObserver::class);
     }
 
     /**

--- a/src/LoveServiceProvider.php
+++ b/src/LoveServiceProvider.php
@@ -20,6 +20,8 @@ use Cog\Laravel\Love\Console\Commands\SetupReacterable;
 use Cog\Laravel\Love\Console\Commands\UpgradeV5ToV6;
 use Cog\Laravel\Love\Reactant\Listeners\DecrementAggregates;
 use Cog\Laravel\Love\Reactant\Listeners\IncrementAggregates;
+use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
+use Cog\Laravel\Love\Reactant\ReactionCounter\Observers\ReactionCounterObserver;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenAdded;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenRemoved;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
@@ -72,6 +74,7 @@ final class LoveServiceProvider extends ServiceProvider
     private function registerObservers(): void
     {
         Reaction::observe(ReactionObserver::class);
+        ReactionCounter::observe(ReactionCounterObserver::class);
     }
 
     /**

--- a/src/Reactant/ReactionCounter/Models/ReactionCounter.php
+++ b/src/Reactant/ReactionCounter/Models/ReactionCounter.php
@@ -24,10 +24,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 final class ReactionCounter extends Model implements
     ReactionCounterContract
 {
+    const DEFAULT_COUNT = 0;
+
     protected $table = 'love_reactant_reaction_counters';
 
     protected $attributes = [
-        'count' => 0,
+        'count' => self::DEFAULT_COUNT,
         'weight' => 0,
     ];
 

--- a/src/Reactant/ReactionCounter/Models/ReactionCounter.php
+++ b/src/Reactant/ReactionCounter/Models/ReactionCounter.php
@@ -26,11 +26,13 @@ final class ReactionCounter extends Model implements
 {
     const DEFAULT_COUNT = 0;
 
+    const DEFAULT_WEIGHT = 0;
+
     protected $table = 'love_reactant_reaction_counters';
 
     protected $attributes = [
         'count' => self::DEFAULT_COUNT,
-        'weight' => 0,
+        'weight' => self::DEFAULT_WEIGHT,
     ];
 
     protected $fillable = [

--- a/src/Reactant/ReactionCounter/Observers/ReactionCounterObserver.php
+++ b/src/Reactant/ReactionCounter/Observers/ReactionCounterObserver.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Laravel Love.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Laravel\Love\Reactant\ReactionCounter\Observers;
+
+use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
+
+final class ReactionCounterObserver
+{
+    public function creating(
+        ReactionCounter $counter
+    ): void {
+        if (is_null($counter->getAttributeValue('count'))) {
+            $counter->setAttribute('count', ReactionCounter::DEFAULT_COUNT);
+        }
+    }
+}

--- a/src/Reactant/ReactionCounter/Observers/ReactionCounterObserver.php
+++ b/src/Reactant/ReactionCounter/Observers/ReactionCounterObserver.php
@@ -23,5 +23,9 @@ final class ReactionCounterObserver
         if (is_null($counter->getAttributeValue('count'))) {
             $counter->setAttribute('count', ReactionCounter::DEFAULT_COUNT);
         }
+
+        if (is_null($counter->getAttributeValue('weight'))) {
+            $counter->setAttribute('weight', ReactionCounter::DEFAULT_WEIGHT);
+        }
     }
 }

--- a/src/Reactant/ReactionTotal/Models/ReactionTotal.php
+++ b/src/Reactant/ReactionTotal/Models/ReactionTotal.php
@@ -22,6 +22,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 final class ReactionTotal extends Model implements
     ReactionTotalContract
 {
+    const DEFAULT_COUNT = 0;
+
+    const DEFAULT_WEIGHT = 0;
+
     protected $table = 'love_reactant_reaction_totals';
 
     protected $attributes = [

--- a/src/Reactant/ReactionTotal/Models/ReactionTotal.php
+++ b/src/Reactant/ReactionTotal/Models/ReactionTotal.php
@@ -29,8 +29,8 @@ final class ReactionTotal extends Model implements
     protected $table = 'love_reactant_reaction_totals';
 
     protected $attributes = [
-        'count' => 0,
-        'weight' => 0,
+        'count' => self::DEFAULT_COUNT,
+        'weight' => self::DEFAULT_WEIGHT,
     ];
 
     protected $fillable = [

--- a/src/Reactant/ReactionTotal/Observers/ReactionTotalObserver.php
+++ b/src/Reactant/ReactionTotal/Observers/ReactionTotalObserver.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Laravel Love.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Laravel\Love\Reactant\ReactionTotal\Observers;
+
+use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
+
+final class ReactionTotalObserver
+{
+    public function creating(
+        ReactionTotal $total
+    ): void {
+        if (is_null($total->getAttributeValue('count'))) {
+            $total->setAttribute('count', ReactionTotal::DEFAULT_COUNT);
+        }
+
+        if (is_null($total->getAttributeValue('weight'))) {
+            $total->setAttribute('weight', ReactionTotal::DEFAULT_WEIGHT);
+        }
+    }
+}

--- a/tests/Unit/Reactant/ReactionCounter/Observers/ReactionCounterObserverTest.php
+++ b/tests/Unit/Reactant/ReactionCounter/Observers/ReactionCounterObserverTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Laravel Love.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Tests\Laravel\Love\Unit\Reactant\ReactionCounter\Observers;
+
+use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
+use Cog\Tests\Laravel\Love\TestCase;
+
+final class ReactionCounterObserverTest extends TestCase
+{
+    /** @test */
+    public function it_sets_default_count_value_when_count_value_is_null(): void
+    {
+        $counter = factory(ReactionCounter::class)->create([
+            'count' => null,
+        ]);
+
+        $this->assertSame(ReactionCounter::DEFAULT_COUNT, $counter->getCount());
+    }
+}

--- a/tests/Unit/Reactant/ReactionCounter/Observers/ReactionCounterObserverTest.php
+++ b/tests/Unit/Reactant/ReactionCounter/Observers/ReactionCounterObserverTest.php
@@ -27,4 +27,14 @@ final class ReactionCounterObserverTest extends TestCase
 
         $this->assertSame(ReactionCounter::DEFAULT_COUNT, $counter->getCount());
     }
+
+    /** @test */
+    public function it_sets_default_weight_value_when_weight_value_is_null(): void
+    {
+        $counter = factory(ReactionCounter::class)->create([
+            'weight' => null,
+        ]);
+
+        $this->assertSame(ReactionCounter::DEFAULT_WEIGHT, $counter->getWeight());
+    }
 }

--- a/tests/Unit/Reactant/ReactionTotal/Observers/ReactionTotalObserverTest.php
+++ b/tests/Unit/Reactant/ReactionTotal/Observers/ReactionTotalObserverTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Laravel Love.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Tests\Laravel\Love\Unit\Reactant\ReactionTotal\Observers;
+
+use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
+use Cog\Tests\Laravel\Love\TestCase;
+
+final class ReactionTotalObserverTest extends TestCase
+{
+    /** @test */
+    public function it_sets_default_count_value_when_count_value_is_null(): void
+    {
+        $total = factory(ReactionTotal::class)->create([
+            'count' => null,
+        ]);
+
+        $this->assertSame(ReactionTotal::DEFAULT_COUNT, $total->getCount());
+    }
+
+    /** @test */
+    public function it_sets_default_weight_value_when_weight_value_is_null(): void
+    {
+        $total = factory(ReactionTotal::class)->create([
+            'weight' => null,
+        ]);
+
+        $this->assertSame(ReactionTotal::DEFAULT_WEIGHT, $total->getWeight());
+    }
+}


### PR DESCRIPTION
## Motivation

Make only one place where default attribute values are declared.

## Current Implementation

`ReactionCounter` & `ReactionTotal` attributes `count` & `weight` default values defined on database layer and in `$attributes` array of the model.

## New Implementation

`ReactionCounter` & `ReactionTotal` model classes will have constants for each attribute default value:
- `ReactionCounter::DEFAULT_COUNT`
- `ReactionCounter::DEFAULT_WEIGHT`
- `ReactionTotal::DEFAULT_COUNT`
- `ReactionTotal::DEFAULT_WEIGHT`