### PR TITLE
Weighted Reaction System 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ## [Unreleased]
 
+Code has a lot of breaking changes because of new Weighted Reaction System.
+
+Follow [upgrade instructions](UPGRADING.md#from-v7-to-v8) to migrate code & database to new structure.
+
 ### Added
 
 - Added `love:upgrade-v7-to-v8` Artisan command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,32 +6,34 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ### Added
 
-- ([#90]) Added `ReactionCounter::DEFAULT_COUNT` & `ReactionCounter::DEFAULT_WEIGHT` constants
-- ([#90]) Added `ReactionTotal::DEFAULT_COUNT` & `ReactionTotal::DEFAULT_WEIGHT` constants
+- ([#90]) Added `ReactionCounter::DEFAULT_COUNT` constant
+- ([#90]) Added `ReactionCounter::DEFAULT_WEIGHT` constant
+- ([#90]) Added `ReactionTotal::DEFAULT_COUNT` constant
+- ([#90]) Added `ReactionTotal::DEFAULT_WEIGHT` constant
 - ([#91]) Added `Reaction::DEFAULT_RATE` constant
 
 ### Changed
 
-- ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reacter model `isReactedTo` & `isReactedToWithType` methods replaced with single `hasReactedTo` method
-- ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reacter model `isNotReactedTo` & `isNotReactedToWithType` methods replaced with single `hasNotReactedTo` method
-- ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reactant model `isReactedBy`&& `isReactedByWithType` methods replaced with single `isReactedBy` method
-- ([#79](https://github.com/cybercog/laravel-love/pull/79)) Reactant model `isNotReactedBy`&& `isNotReactedByWithType` methods replaced with single `isNotReactedBy` method
-- ([#83](https://github.com/cybercog/laravel-love/pull/83)) Artisan command `love:reaction-type-add` awaits options instead of arguments
-- ([#87](https://github.com/cybercog/laravel-love/pull/87)) Resolving default attributes values moved from accessors to Eloquent
-- ([#88](https://github.com/cybercog/laravel-love/pull/88)) ReactionType attribute `weight` renamed to `mass`
-- ([#88](https://github.com/cybercog/laravel-love/pull/88)) ReactionType method `getWeight` renamed to `getMass`
-- ([#89](https://github.com/cybercog/laravel-love/pull/89)) Reactable method `scopeWhereReactedByWithType` merged with `scopeWhereReactedBy`
-- ([#90](https://github.com/cybercog/laravel-love/pull/90)) ReactionCounter attributes `count` & `weight` default values moved to application level
-- ([#90](https://github.com/cybercog/laravel-love/pull/90)) ReactionTotal attributes `count` & `weight` default values moved to application level
-- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
-- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `$amount` parameter  type from `int` to `float` of `incrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
-- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `$amount` parameter  type from `int` to `float` of `decrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
-- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
-- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `$amount` parameter  type from `int` to `float` of `incrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
-- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `$amount` parameter  type from `int` to `float` of `decrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
-- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Added `?float $rate` parameter to `reactTo` method in `Cog\Contracts\Love\Reacter\Models\Reacter` contract
-- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Added `getRate` method to `Cog\Contracts\Love\Reaction\Models\Reaction` contract
-- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reaction\Models\Reaction` contract
+- ([#79]) Reacter model `isReactedTo` & `isReactedToWithType` methods replaced with single `hasReactedTo` method
+- ([#79]) Reacter model `isNotReactedTo` & `isNotReactedToWithType` methods replaced with single `hasNotReactedTo` method
+- ([#79]) Reactant model `isReactedBy`&& `isReactedByWithType` methods replaced with single `isReactedBy` method
+- ([#79]) Reactant model `isNotReactedBy`&& `isNotReactedByWithType` methods replaced with single `isNotReactedBy` method
+- ([#83]) Artisan command `love:reaction-type-add` awaits options instead of arguments
+- ([#87]) Resolving default attributes values moved from accessors to Eloquent
+- ([#88]) ReactionType attribute `weight` renamed to `mass`
+- ([#88]) ReactionType method `getWeight` renamed to `getMass`
+- ([#89]) Reactable method `scopeWhereReactedByWithType` merged with `scopeWhereReactedBy`
+- ([#90]) ReactionCounter attributes `count` & `weight` default values moved to application level
+- ([#90]) ReactionTotal attributes `count` & `weight` default values moved to application level
+- ([#91]) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
+- ([#91]) Changed `$amount` parameter  type from `int` to `float` of `incrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
+- ([#91]) Changed `$amount` parameter  type from `int` to `float` of `decrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
+- ([#91]) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
+- ([#91]) Changed `$amount` parameter  type from `int` to `float` of `incrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
+- ([#91]) Changed `$amount` parameter  type from `int` to `float` of `decrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
+- ([#91]) Added `?float $rate` parameter to `reactTo` method in `Cog\Contracts\Love\Reacter\Models\Reacter` contract
+- ([#91]) Added `getRate` method to `Cog\Contracts\Love\Reaction\Models\Reaction` contract
+- ([#91]) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reaction\Models\Reaction` contract
 
 ### Removed
 
@@ -350,4 +352,10 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#79]: https://github.com/cybercog/laravel-love/pull/79
+[#83]: https://github.com/cybercog/laravel-love/pull/83
+[#87]: https://github.com/cybercog/laravel-love/pull/87
+[#88]: https://github.com/cybercog/laravel-love/pull/88
+[#89]: https://github.com/cybercog/laravel-love/pull/89
+[#90]: https://github.com/cybercog/laravel-love/pull/90
 [#91]: https://github.com/cybercog/laravel-love/pull/91

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ### Added
 
-- ([#90](https://github.com/cybercog/laravel-love/pull/90)) Added `ReactionCounter::DEFAULT_COUNT` & `ReactionCounter::DEFAULT_WEIGHT` constants
-- ([#90](https://github.com/cybercog/laravel-love/pull/90)) Added `ReactionTotal::DEFAULT_COUNT` & `ReactionTotal::DEFAULT_WEIGHT` constants
+- ([#90]) Added `ReactionCounter::DEFAULT_COUNT` & `ReactionCounter::DEFAULT_WEIGHT` constants
+- ([#90]) Added `ReactionTotal::DEFAULT_COUNT` & `ReactionTotal::DEFAULT_WEIGHT` constants
 - ([#91]) Added `Reaction::DEFAULT_RATE` constant
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#91]) Added `ReactionType::MASS_DEFAULT` public constant
 - ([#91]) Added `rate` attribute to `Reacter` model
 - ([#91]) Added `rate DECIMIAL(4, 2)` column to `love_reactions` db table
-- ([#91]) Added ability to `Reacter::reactTo` with already reacted reactant, same reaction type, but only `rate` differs
+- ([#91]) Added ability to call `Reacter::reactTo` with already reacted reactant, same reaction type, but only `rate` differs
+- ([#91]) Added `Cog\Contracts\Love\Reaction\Exceptions\RateOutOfRange` exception
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to `laravel-love` will be documented in this file.
 
 - ([#90](https://github.com/cybercog/laravel-love/pull/90)) Added `ReactionCounter::DEFAULT_COUNT` & `ReactionCounter::DEFAULT_WEIGHT` constants
 - ([#90](https://github.com/cybercog/laravel-love/pull/90)) Added `ReactionTotal::DEFAULT_COUNT` & `ReactionTotal::DEFAULT_WEIGHT` constants
-- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Added `Reaction::DEFAULT_RATE` constant
+- ([#91]) Added `Reaction::DEFAULT_RATE` constant
 
 ### Changed
 
@@ -349,3 +349,5 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.2]: https://github.com/cybercog/laravel-love/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
+
+[#91]: https://github.com/cybercog/laravel-love/pull/91

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#90]) Added `ReactionTotal::DEFAULT_COUNT` constant
 - ([#90]) Added `ReactionTotal::DEFAULT_WEIGHT` constant
 - ([#91]) Added `Reaction::DEFAULT_RATE` constant
+- ([#91]) Added `ReactionType::DEFAULT_MASS` constant
 - ([#91]) Added `rate` attribute to `Reacter` model
 - ([#91]) Added `rate DECIMIAL(4, 2)` column to `love_reactions` db table
 - ([#91]) Added ability to call `Reacter::reactTo` on already reacted reactant with same reaction type if rate differs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,8 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#91]) Added `?float $rate` parameter to `reactTo` method in `Reacter` model contract
 - ([#91]) Added `getRate` method to `Reaction` model contract
 - ([#91]) Changed `getWeight` method return type from `int` to `float` in `Reaction` model contract
-- ([#91]) Changed `weight` column type to `DECIMIAL(22, 2)` in `love_reactant_reaction_counters` db table
-- ([#91]) Changed `weight` column type to `DECIMIAL(22, 2)` in `love_reactant_reaction_totals` db table
+- ([#91]) Changed `weight` column type to `DECIMIAL(13, 2)` in `love_reactant_reaction_counters` db table
+- ([#91]) Changed `weight` column type to `DECIMIAL(13, 2)` in `love_reactant_reaction_totals` db table
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,16 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ### Changed
 
-- ([#79]) `Reacter` model `isReactedTo` & `isReactedToWithType` methods replaced with single `hasReactedTo` method
-- ([#79]) `Reacter` model `isNotReactedTo` & `isNotReactedToWithType` methods replaced with single `hasNotReactedTo` method
-- ([#79]) `Reactant` model `isReactedBy`&& `isReactedByWithType` methods replaced with single `isReactedBy` method
-- ([#79]) `Reactant` model `isNotReactedBy`&& `isNotReactedByWithType` methods replaced with single `isNotReactedBy` method
+- ([#79]) Method `isReactedTo` renamed to `hasReactedTo` in `Reacter` model contract
+- ([#79]) Added `$reactionType` parameter to `hasReactedTo` in `Reacter` model contract
+- ([#91]) Added `$rate` parameter to `hasReactedTo` method in  `Reacter` model contract
+- ([#79]) Method `isNotReactedTo` renamed to `hasNotReactedTo` in `Reacter` model contract
+- ([#79]) Added `$reactionType` parameter to `hasNotReactedTo` in `Reacter` model contract
+- ([#91]) Added `$rate` parameter to `hasNotReactedTo` method in  `Reacter` model contract
+- ([#79]) Added `$reactionType` parameter to `isReactedBy` in `Reactant` model contract
+- ([#91]) Added `$rate` parameter to `isReactedBy` method in  `Reactant` model contract
+- ([#79]) Added `$reactionType` parameter to `isNotReactedBy` in `Reactant` model contract
+- ([#91]) Added `$rate` parameter to `isNotReactedBy` method in  `Reactant` model contract
 - ([#83]) Artisan command `love:reaction-type-add` awaits options instead of arguments
 - ([#87]) Resolving default attributes values moved from accessors to Eloquent
 - ([#88]) `ReactionType` model attribute `weight` renamed to `mass`
@@ -44,7 +50,11 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ### Removed
 
-- ([#86](https://github.com/cybercog/laravel-love/pull/86)) Laravel 5.6 support obsolete
+- ([#86]) Laravel 5.6 support obsolete
+- ([#79]) `Reacter` model contract `isReactedToWithType` method removed
+- ([#79]) `Reacter` model contract `isNotReactedToWithType` method removed
+- ([#79]) `Reactant` model contract `isReactedByWithType` method removed
+- ([#79]) `Reactant` model contract `isNotReactedByWithType` method removed
 
 ## [7.2.1] - 2019-07-11
 
@@ -361,6 +371,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 
 [#79]: https://github.com/cybercog/laravel-love/pull/79
 [#83]: https://github.com/cybercog/laravel-love/pull/83
+[#86]: https://github.com/cybercog/laravel-love/pull/86
 [#87]: https://github.com/cybercog/laravel-love/pull/87
 [#88]: https://github.com/cybercog/laravel-love/pull/88
 [#89]: https://github.com/cybercog/laravel-love/pull/89

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,20 +11,23 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#90]) Added `ReactionTotal::DEFAULT_COUNT` constant
 - ([#90]) Added `ReactionTotal::DEFAULT_WEIGHT` constant
 - ([#91]) Added `Reaction::DEFAULT_RATE` constant
+- ([#91]) Added `rate` attribute to `Reacter` model
+- ([#91]) Added `rate DECIMIAL(4, 2)` column to `love_reactions` db table
+- ([#91]) Added ability to call `Reacter::reactTo` on already reacted reactant with same reaction type if rate differs
 
 ### Changed
 
-- ([#79]) Reacter model `isReactedTo` & `isReactedToWithType` methods replaced with single `hasReactedTo` method
-- ([#79]) Reacter model `isNotReactedTo` & `isNotReactedToWithType` methods replaced with single `hasNotReactedTo` method
-- ([#79]) Reactant model `isReactedBy`&& `isReactedByWithType` methods replaced with single `isReactedBy` method
-- ([#79]) Reactant model `isNotReactedBy`&& `isNotReactedByWithType` methods replaced with single `isNotReactedBy` method
+- ([#79]) `Reacter` model `isReactedTo` & `isReactedToWithType` methods replaced with single `hasReactedTo` method
+- ([#79]) `Reacter` model `isNotReactedTo` & `isNotReactedToWithType` methods replaced with single `hasNotReactedTo` method
+- ([#79]) `Reactant` model `isReactedBy`&& `isReactedByWithType` methods replaced with single `isReactedBy` method
+- ([#79]) `Reactant` model `isNotReactedBy`&& `isNotReactedByWithType` methods replaced with single `isNotReactedBy` method
 - ([#83]) Artisan command `love:reaction-type-add` awaits options instead of arguments
 - ([#87]) Resolving default attributes values moved from accessors to Eloquent
-- ([#88]) ReactionType attribute `weight` renamed to `mass`
-- ([#88]) ReactionType method `getWeight` renamed to `getMass`
-- ([#89]) Reactable method `scopeWhereReactedByWithType` merged with `scopeWhereReactedBy`
-- ([#90]) ReactionCounter attributes `count` & `weight` default values moved to application level
-- ([#90]) ReactionTotal attributes `count` & `weight` default values moved to application level
+- ([#88]) `ReactionType` model attribute `weight` renamed to `mass`
+- ([#88]) `ReactionType` model method `getWeight` renamed to `getMass`
+- ([#89]) `Reactable` model method `scopeWhereReactedByWithType` merged with `scopeWhereReactedBy`
+- ([#90]) `ReactionCounter` model attributes `count` & `weight` default values moved to application level
+- ([#90]) `ReactionTotal` model attributes `count` & `weight` default values moved to application level
 - ([#91]) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
 - ([#91]) Changed `$amount` parameter  type from `int` to `float` of `incrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
 - ([#91]) Changed `$amount` parameter  type from `int` to `float` of `decrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
@@ -34,6 +37,8 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#91]) Added `?float $rate` parameter to `reactTo` method in `Cog\Contracts\Love\Reacter\Models\Reacter` contract
 - ([#91]) Added `getRate` method to `Cog\Contracts\Love\Reaction\Models\Reaction` contract
 - ([#91]) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reaction\Models\Reaction` contract
+- ([#91]) Changed `weight` column type to `DECIMIAL(22, 2)` in `love_reactant_reaction_counters` db table
+- ([#91]) Changed `weight` column type to `DECIMIAL(22, 2)` in `love_reactant_reaction_totals` db table
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ### Added
 
+- Added `love:upgrade-v7-to-v8` Artisan command
 - ([#90]) Added `ReactionCounter::DEFAULT_COUNT` constant
 - ([#90]) Added `ReactionCounter::DEFAULT_WEIGHT` constant
 - ([#90]) Added `ReactionTotal::DEFAULT_COUNT` constant
@@ -14,47 +15,52 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#91]) Added `ReactionType::DEFAULT_MASS` constant
 - ([#91]) Added `rate` attribute to `Reacter` model
 - ([#91]) Added `rate DECIMIAL(4, 2)` column to `love_reactions` db table
-- ([#91]) Added ability to call `Reacter::reactTo` on already reacted reactant with same reaction type if rate differs
+- ([#91]) Added ability to `Reacter::reactTo` with already reacted reactant, same reaction type, but only `rate` differs
 
 ### Changed
 
-- ([#79]) Method `isReactedTo` renamed to `hasReactedTo` in `Reacter` model contract
+- ([#79]) Renamed `isReactedTo` method to `hasReactedTo` in `Reacter` model contract
 - ([#79]) Added `$reactionType` parameter to `hasReactedTo` in `Reacter` model contract
-- ([#91]) Added `$rate` parameter to `hasReactedTo` method in  `Reacter` model contract
-- ([#79]) Method `isNotReactedTo` renamed to `hasNotReactedTo` in `Reacter` model contract
+- ([#91]) Added `$rate` parameter to `hasReactedTo` method in `Reacter` model contract
+- ([#91]) Added `$rate` parameter to `hasReactedTo` method in `Reacter` facade contract
+- ([#79]) Renamed `isNotReactedTo` method to `hasNotReactedTo` in `Reacter` model contract
 - ([#79]) Added `$reactionType` parameter to `hasNotReactedTo` in `Reacter` model contract
-- ([#91]) Added `$rate` parameter to `hasNotReactedTo` method in  `Reacter` model contract
+- ([#91]) Added `$rate` parameter to `hasNotReactedTo` method in `Reacter` model contract
+- ([#91]) Added `$rate` parameter to `hasNotReactedTo` method in `Reacter` facade contract
 - ([#79]) Added `$reactionType` parameter to `isReactedBy` in `Reactant` model contract
-- ([#91]) Added `$rate` parameter to `isReactedBy` method in  `Reactant` model contract
+- ([#91]) Added `$rate` parameter to `isReactedBy` method in `Reactant` model contract
+- ([#91]) Added `$rate` parameter to `isReactedBy` method in `Reactant` facade contract
 - ([#79]) Added `$reactionType` parameter to `isNotReactedBy` in `Reactant` model contract
-- ([#91]) Added `$rate` parameter to `isNotReactedBy` method in  `Reactant` model contract
+- ([#91]) Added `$rate` parameter to `isNotReactedBy` method in `Reactant` model contract
+- ([#91]) Added `$rate` parameter to `isNotReactedBy` method in `Reactant` facade contract
 - ([#83]) Artisan command `love:reaction-type-add` awaits options instead of arguments
-- ([#87]) Resolving default attributes values moved from accessors to Eloquent
-- ([#88]) `ReactionType` model attribute `weight` renamed to `mass`
-- ([#88]) `ReactionType` model method `getWeight` renamed to `getMass`
-- ([#89]) `Reactable` model method `scopeWhereReactedByWithType` merged with `scopeWhereReactedBy`
-- ([#90]) `ReactionCounter` model attributes `count` & `weight` default values moved to application level
-- ([#90]) `ReactionTotal` model attributes `count` & `weight` default values moved to application level
-- ([#91]) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
-- ([#91]) Changed `$amount` parameter  type from `int` to `float` of `incrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
-- ([#91]) Changed `$amount` parameter  type from `int` to `float` of `decrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
-- ([#91]) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
-- ([#91]) Changed `$amount` parameter  type from `int` to `float` of `incrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
-- ([#91]) Changed `$amount` parameter  type from `int` to `float` of `decrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
-- ([#91]) Added `?float $rate` parameter to `reactTo` method in `Cog\Contracts\Love\Reacter\Facades\Reacter` contract
-- ([#91]) Added `?float $rate` parameter to `reactTo` method in `Cog\Contracts\Love\Reacter\Models\Reacter` contract
-- ([#91]) Added `getRate` method to `Cog\Contracts\Love\Reaction\Models\Reaction` contract
-- ([#91]) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reaction\Models\Reaction` contract
+- ([#87]) Resolving models default attributes values moved from accessors to Eloquent methods
+- ([#88]) Renamed `weight` attribute to `mass` in `ReactionType` model
+- ([#88]) Renamed `getWeight` method to `getMass` in `ReactionType` model contract
+- ([#89]) Added `$reactionType` parameter to `scopeWhereReactedBy` method in `Reactable` model trait
+- ([#90]) Moved `count` & `weight` attributes default values of `ReactionCounter` to application level
+- ([#90]) Moved `count` & `weight` attributes default values of `ReactionTotal` to application level
+- ([#91]) Changed `getWeight` method return type from `int` to `float` in reactant's `ReactionCounter` model contract
+- ([#91]) Changed `$amount` parameter  type from `int` to `float` of `incrementWeight` method in reactant's `ReactionCounter` model contract
+- ([#91]) Changed `$amount` parameter  type from `int` to `float` of `decrementWeight` method in reactant's `ReactionCounter` model contract
+- ([#91]) Changed `getWeight` method return type from `int` to `float` in reactant's `ReactionTotal` model contract
+- ([#91]) Changed `$amount` parameter  type from `int` to `float` of `incrementWeight` method in reactant's `ReactionTotal` model contract
+- ([#91]) Changed `$amount` parameter  type from `int` to `float` of `decrementWeight` method in reactant's `ReactionTotal` model contract
+- ([#91]) Added `?float $rate` parameter to `reactTo` method in `Reacter` facade contract
+- ([#91]) Added `?float $rate` parameter to `reactTo` method in `Reacter` model contract
+- ([#91]) Added `getRate` method to `Reaction` model contract
+- ([#91]) Changed `getWeight` method return type from `int` to `float` in `Reaction` model contract
 - ([#91]) Changed `weight` column type to `DECIMIAL(22, 2)` in `love_reactant_reaction_counters` db table
 - ([#91]) Changed `weight` column type to `DECIMIAL(22, 2)` in `love_reactant_reaction_totals` db table
 
 ### Removed
 
 - ([#86]) Laravel 5.6 support obsolete
-- ([#79]) `Reacter` model contract `isReactedToWithType` method removed
-- ([#79]) `Reacter` model contract `isNotReactedToWithType` method removed
-- ([#79]) `Reactant` model contract `isReactedByWithType` method removed
-- ([#79]) `Reactant` model contract `isNotReactedByWithType` method removed
+- ([#79]) Removed `isReactedToWithType` method from `Reacter` model contract
+- ([#79]) Removed `isNotReactedToWithType` method from `Reacter` model contract
+- ([#79]) Removed `isReactedByWithType` method from `Reactant` model contract
+- ([#79]) Removed `isNotReactedByWithType` method `Reactant` model contract
+- ([#89]) Removed `scopeWhereReactedByWithType` method from `Reactable` model trait
 
 ## [7.2.1] - 2019-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#91]) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
 - ([#91]) Changed `$amount` parameter  type from `int` to `float` of `incrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
 - ([#91]) Changed `$amount` parameter  type from `int` to `float` of `decrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
+- ([#91]) Added `?float $rate` parameter to `reactTo` method in `Cog\Contracts\Love\Reacter\Facades\Reacter` contract
 - ([#91]) Added `?float $rate` parameter to `reactTo` method in `Cog\Contracts\Love\Reacter\Models\Reacter` contract
 - ([#91]) Added `getRate` method to `Cog\Contracts\Love\Reaction\Models\Reaction` contract
 - ([#91]) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reaction\Models\Reaction` contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ All notable changes to `laravel-love` will be documented in this file.
 ### Added
 
 - Added `love:upgrade-v7-to-v8` Artisan command
-- ([#90]) Added `ReactionCounter::DEFAULT_COUNT` constant
-- ([#90]) Added `ReactionCounter::DEFAULT_WEIGHT` constant
-- ([#90]) Added `ReactionTotal::DEFAULT_COUNT` constant
-- ([#90]) Added `ReactionTotal::DEFAULT_WEIGHT` constant
-- ([#91]) Added `Reaction::DEFAULT_RATE` constant
-- ([#91]) Added `ReactionType::DEFAULT_MASS` constant
+- ([#90]) Added `ReactionCounter::COUNT_DEFAULT` public constant
+- ([#90]) Added `ReactionCounter::WEIGHT_DEFAULT` public constant
+- ([#90]) Added `ReactionTotal::COUNT_DEFAULT` public constant
+- ([#90]) Added `ReactionTotal::WEIGHT_DEFAULT` public constant
+- ([#91]) Added `Reaction::RATE_DEFAULT` public constant
+- ([#91]) Added `Reaction::RATE_MIN` public constant
+- ([#91]) Added `Reaction::RATE_MAX` public constant
+- ([#91]) Added `ReactionType::MASS_DEFAULT` public constant
 - ([#91]) Added `rate` attribute to `Reacter` model
 - ([#91]) Added `rate DECIMIAL(4, 2)` column to `love_reactions` db table
 - ([#91]) Added ability to `Reacter::reactTo` with already reacted reactant, same reaction type, but only `rate` differs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `laravel-love` will be documented in this file.
 
 - ([#90](https://github.com/cybercog/laravel-love/pull/90)) Added `ReactionCounter::DEFAULT_COUNT` & `ReactionCounter::DEFAULT_WEIGHT` constants
 - ([#90](https://github.com/cybercog/laravel-love/pull/90)) Added `ReactionTotal::DEFAULT_COUNT` & `ReactionTotal::DEFAULT_WEIGHT` constants
+- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Added `Reaction::DEFAULT_RATE` constant
 
 ### Changed
 
@@ -22,6 +23,15 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#89](https://github.com/cybercog/laravel-love/pull/89)) Reactable method `scopeWhereReactedByWithType` merged with `scopeWhereReactedBy`
 - ([#90](https://github.com/cybercog/laravel-love/pull/90)) ReactionCounter attributes `count` & `weight` default values moved to application level
 - ([#90](https://github.com/cybercog/laravel-love/pull/90)) ReactionTotal attributes `count` & `weight` default values moved to application level
+- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
+- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `$amount` parameter  type from `int` to `float` of `incrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
+- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `$amount` parameter  type from `int` to `float` of `decrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter` contract
+- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
+- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `$amount` parameter  type from `int` to `float` of `incrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
+- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `$amount` parameter  type from `int` to `float` of `decrementWeight` method in `Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal` contract
+- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Added `?float $rate` parameter to `reactTo` method in `Cog\Contracts\Love\Reacter\Models\Reacter` contract
+- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Added `getRate` method to `Cog\Contracts\Love\Reaction\Models\Reaction` contract
+- ([#91](https://github.com/cybercog/laravel-love/pull/91)) Changed `getWeight` method return type from `int` to `float` in `Cog\Contracts\Love\Reaction\Models\Reaction` contract
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@
 
 ## From v7 to v8
 
+- All `weight` values are `float` now. Round them to get `integer` values as it was before.
 - Find all `isReactedTo` method usages and replace it with `hasReactedTo`
 - Find all `isReactedToWithType` method usages and replace it with `hasReactedTo`
 - Find all `isNotReactedTo` method usages and replace it with `hasNotReactedTo`

--- a/contracts/Reactant/Facades/Reactant.php
+++ b/contracts/Reactant/Facades/Reactant.php
@@ -27,7 +27,7 @@ interface Reactant
 
     public function getReactionTotal(): ReactionTotal;
 
-    public function isReactedBy(Reacterable $reacterable, ?string $reactionTypeName = null): bool;
+    public function isReactedBy(Reacterable $reacterable, ?string $reactionTypeName = null, ?float $rate = null): bool;
 
-    public function isNotReactedBy(Reacterable $reacterable, ?string $reactionTypeName = null): bool;
+    public function isNotReactedBy(Reacterable $reacterable, ?string $reactionTypeName = null, ?float $rate = null): bool;
 }

--- a/contracts/Reactant/Models/Reactant.php
+++ b/contracts/Reactant/Models/Reactant.php
@@ -39,9 +39,9 @@ interface Reactant
 
     public function getReactionTotal(): ReactionTotal;
 
-    public function isReactedBy(Reacter $reacter, ?ReactionType $reactionType = null): bool;
+    public function isReactedBy(Reacter $reacter, ?ReactionType $reactionType = null, ?float $rate = null): bool;
 
-    public function isNotReactedBy(Reacter $reacter, ?ReactionType $reactionType = null): bool;
+    public function isNotReactedBy(Reacter $reacter, ?ReactionType $reactionType = null, ?float $rate = null): bool;
 
     public function isEqualTo(self $that): bool;
 

--- a/contracts/Reactant/ReactionCounter/Models/ReactionCounter.php
+++ b/contracts/Reactant/ReactionCounter/Models/ReactionCounter.php
@@ -28,13 +28,13 @@ interface ReactionCounter
 
     public function getCount(): int;
 
-    public function getWeight(): int;
+    public function getWeight(): float;
 
     public function incrementCount(int $amount): void;
 
     public function decrementCount(int $amount): void;
 
-    public function incrementWeight(int $amount): void;
+    public function incrementWeight(float $amount): void;
 
-    public function decrementWeight(int $amount): void;
+    public function decrementWeight(float $amount): void;
 }

--- a/contracts/Reactant/ReactionTotal/Models/ReactionTotal.php
+++ b/contracts/Reactant/ReactionTotal/Models/ReactionTotal.php
@@ -21,13 +21,13 @@ interface ReactionTotal
 
     public function getCount(): int;
 
-    public function getWeight(): int;
+    public function getWeight(): float;
 
     public function incrementCount(int $amount): void;
 
     public function decrementCount(int $amount): void;
 
-    public function incrementWeight(int $amount): void;
+    public function incrementWeight(float $amount): void;
 
-    public function decrementWeight(int $amount): void;
+    public function decrementWeight(float $amount): void;
 }

--- a/contracts/Reacter/Facades/Reacter.php
+++ b/contracts/Reacter/Facades/Reacter.php
@@ -23,7 +23,7 @@ interface Reacter
 
     public function unreactTo(Reactable $reactable, string $reactionTypeName): void;
 
-    public function hasReactedTo(Reactable $reactable, ?string $reactionTypeName = null): bool;
+    public function hasReactedTo(Reactable $reactable, ?string $reactionTypeName = null, ?float $rate = null): bool;
 
-    public function hasNotReactedTo(Reactable $reactable, ?string $reactionTypeName = null): bool;
+    public function hasNotReactedTo(Reactable $reactable, ?string $reactionTypeName = null, ?float $rate = null): bool;
 }

--- a/contracts/Reacter/Facades/Reacter.php
+++ b/contracts/Reacter/Facades/Reacter.php
@@ -19,7 +19,7 @@ interface Reacter
 {
     public function getReactions(): iterable;
 
-    public function reactTo(Reactable $reactable, string $reactionTypeName): void;
+    public function reactTo(Reactable $reactable, string $reactionTypeName, ?float $rate = null): void;
 
     public function unreactTo(Reactable $reactable, string $reactionTypeName): void;
 

--- a/contracts/Reacter/Models/Reacter.php
+++ b/contracts/Reacter/Models/Reacter.php
@@ -28,7 +28,7 @@ interface Reacter
      */
     public function getReactions(): iterable;
 
-    public function reactTo(Reactant $reactant, ReactionType $reactionType): void;
+    public function reactTo(Reactant $reactant, ReactionType $reactionType, ?float $rate = null): void;
 
     public function unreactTo(Reactant $reactant, ReactionType $reactionType): void;
 

--- a/contracts/Reacter/Models/Reacter.php
+++ b/contracts/Reacter/Models/Reacter.php
@@ -32,9 +32,9 @@ interface Reacter
 
     public function unreactTo(Reactant $reactant, ReactionType $reactionType): void;
 
-    public function hasReactedTo(Reactant $reactant, ?ReactionType $reactionType = null): bool;
+    public function hasReactedTo(Reactant $reactant, ?ReactionType $reactionType = null, float $rate = null): bool;
 
-    public function hasNotReactedTo(Reactant $reactant, ?ReactionType $reactionType = null): bool;
+    public function hasNotReactedTo(Reactant $reactant, ?ReactionType $reactionType = null, float $rate = null): bool;
 
     public function isEqualTo(self $that): bool;
 

--- a/contracts/Reaction/Exceptions/RateOutOfRange.php
+++ b/contracts/Reaction/Exceptions/RateOutOfRange.php
@@ -17,7 +17,7 @@ use Cog\Contracts\Love\Exceptions\LoveThrowable;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
 use OutOfRangeException;
 
-final class RateValueInvalid extends OutOfRangeException implements
+final class RateOutOfRange extends OutOfRangeException implements
     LoveThrowable
 {
     public static function withValue(float $rate): self

--- a/contracts/Reaction/Exceptions/RateValueInvalid.php
+++ b/contracts/Reaction/Exceptions/RateValueInvalid.php
@@ -25,8 +25,8 @@ final class RateValueInvalid extends OutOfRangeException implements
         return new self(sprintf(
             "Invalid Reaction rate: `%s`. Must be between `%s` and `%s`",
             $rate,
-            Reaction::MIN_RATE,
-            Reaction::MAX_RATE
+            Reaction::RATE_MIN,
+            Reaction::RATE_MAX
         ));
     }
 }

--- a/contracts/Reaction/Exceptions/RateValueInvalid.php
+++ b/contracts/Reaction/Exceptions/RateValueInvalid.php
@@ -23,7 +23,7 @@ final class RateValueInvalid extends OutOfRangeException implements
     public static function withValue(float $rate): self
     {
         return new self(sprintf(
-            "Invalid Reaction rate: `%s`. Must be between `%s` and `%s`",
+            'Invalid Reaction rate: `%s`. Must be between `%s` and `%s`',
             $rate,
             Reaction::RATE_MIN,
             Reaction::RATE_MAX

--- a/contracts/Reaction/Exceptions/RateValueInvalid.php
+++ b/contracts/Reaction/Exceptions/RateValueInvalid.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of PHP Contracts: Love.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Contracts\Love\Reaction\Exceptions;
+
+use Cog\Contracts\Love\Exceptions\LoveThrowable;
+use Cog\Laravel\Love\Reaction\Models\Reaction;
+use OutOfRangeException;
+
+final class RateValueInvalid extends OutOfRangeException implements
+    LoveThrowable
+{
+    public static function withValue(float $rate): self
+    {
+        return new self(sprintf(
+            "Invalid Reaction rate: `%s`. Must be between `%s` and `%s`",
+            $rate,
+            Reaction::MIN_RATE,
+            Reaction::MAX_RATE
+        ));
+    }
+}

--- a/contracts/Reaction/Models/Reaction.php
+++ b/contracts/Reaction/Models/Reaction.php
@@ -27,7 +27,7 @@ interface Reaction
 
     public function getReacter(): Reacter;
 
-    public function getWeight(): int;
+    public function getWeight(): float;
 
     public function isOfType(ReactionType $type): bool;
 

--- a/contracts/Reaction/Models/Reaction.php
+++ b/contracts/Reaction/Models/Reaction.php
@@ -21,11 +21,13 @@ interface Reaction
 {
     public function getId(): string;
 
-    public function getType(): ReactionType;
-
     public function getReactant(): Reactant;
 
     public function getReacter(): Reacter;
+
+    public function getType(): ReactionType;
+
+    public function getRate(): float;
 
     public function getWeight(): float;
 

--- a/database/migrations/2018_07_22_002000_create_love_reactions_table.php
+++ b/database/migrations/2018_07_22_002000_create_love_reactions_table.php
@@ -29,6 +29,7 @@ final class CreateLoveReactionsTable extends Migration
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('reacter_id');
             $table->unsignedBigInteger('reaction_type_id');
+            $table->double('rate', 4, 2);
             $table->timestamps();
 
             $table->index([

--- a/database/migrations/2018_07_22_002000_create_love_reactions_table.php
+++ b/database/migrations/2018_07_22_002000_create_love_reactions_table.php
@@ -29,7 +29,7 @@ final class CreateLoveReactionsTable extends Migration
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('reacter_id');
             $table->unsignedBigInteger('reaction_type_id');
-            $table->double('rate', 4, 2);
+            $table->decimal('rate', 4, 2);
             $table->timestamps();
 
             $table->index([

--- a/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
+++ b/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
@@ -29,7 +29,7 @@ final class CreateLoveReactantReactionCountersTable extends Migration
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('reaction_type_id');
             $table->unsignedBigInteger('count');
-            $table->decimal('weight', 22, 2);
+            $table->decimal('weight', 13, 2);
             $table->timestamps();
 
             $table->index([

--- a/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
+++ b/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
@@ -29,7 +29,7 @@ final class CreateLoveReactantReactionCountersTable extends Migration
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('reaction_type_id');
             $table->unsignedBigInteger('count');
-            $table->bigInteger('weight');
+            $table->decimal('weight', 22, 2);
             $table->timestamps();
 
             $table->index([

--- a/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
+++ b/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
@@ -28,7 +28,7 @@ final class CreateLoveReactantReactionTotalsTable extends Migration
             $table->bigIncrements('id');
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('count');
-            $table->bigInteger('weight');
+            $table->decimal('weight', 22, 2);
             $table->timestamps();
 
             $table

--- a/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
+++ b/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
@@ -28,7 +28,7 @@ final class CreateLoveReactantReactionTotalsTable extends Migration
             $table->bigIncrements('id');
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('count');
-            $table->decimal('weight', 22, 2);
+            $table->decimal('weight', 13, 2);
             $table->timestamps();
 
             $table

--- a/src/Console/Commands/ReactionTypeAdd.php
+++ b/src/Console/Commands/ReactionTypeAdd.php
@@ -119,7 +119,7 @@ final class ReactionTypeAdd extends Command
     {
         return $this->option('name')
             ?? $this->ask('How to name reaction type?')
-            ?? $this->resolveName();
+            ?? '';
     }
 
     private function resolveMass(): int

--- a/src/Console/Commands/ReactionTypeAdd.php
+++ b/src/Console/Commands/ReactionTypeAdd.php
@@ -124,8 +124,11 @@ final class ReactionTypeAdd extends Command
 
     private function resolveMass(): int
     {
-        return intval($this->option('mass')
-            ?? $this->ask('What is the mass of this reaction type?'));
+        $mass = $this->option('mass')
+            ?? $this->ask('What is the mass of this reaction type?')
+            ?? ReactionType::DEFAULT_MASS;
+
+        return intval($mass);
     }
 
     private function sanitizeName(string $name): string

--- a/src/Console/Commands/ReactionTypeAdd.php
+++ b/src/Console/Commands/ReactionTypeAdd.php
@@ -126,7 +126,7 @@ final class ReactionTypeAdd extends Command
     {
         $mass = $this->option('mass')
             ?? $this->ask('What is the mass of this reaction type?')
-            ?? ReactionType::DEFAULT_MASS;
+            ?? ReactionType::MASS_DEFAULT;
 
         return intval($mass);
     }

--- a/src/Console/Commands/Recount.php
+++ b/src/Console/Commands/Recount.php
@@ -80,7 +80,7 @@ final class Recount extends Command
 
                 $counter->update([
                     'count' => 0,
-                    'weight' => 0,
+                    'weight' => 0.0,
                 ]);
             }
 
@@ -155,7 +155,7 @@ final class Recount extends Command
     ): void {
         $counters = $reactant->getReactionCounters();
         $totalCount = 0;
-        $totalWeight = 0;
+        $totalWeight = 0.0;
         foreach ($counters as $counter) {
             $totalCount += $counter->getCount();
             $totalWeight += $counter->getWeight();

--- a/src/Console/Commands/UpgradeV7ToV8.php
+++ b/src/Console/Commands/UpgradeV7ToV8.php
@@ -90,11 +90,16 @@ final class UpgradeV7ToV8 extends Command
 
     private function getDbSchema(): Builder
     {
-        return Schema::connection(Config::get('love.storage.database.connection'));
+        return Schema::connection($this->getDatabaseConnection());
     }
 
     private function getDbQuery(): ConnectionInterface
     {
-        return DB::connection(Config::get('love.storage.database.connection'));
+        return DB::connection($this->getDatabaseConnection());
+    }
+
+    private function getDatabaseConnection(): ?string
+    {
+        return Config::get('love.storage.database.connection');
     }
 }

--- a/src/Console/Commands/UpgradeV7ToV8.php
+++ b/src/Console/Commands/UpgradeV7ToV8.php
@@ -44,22 +44,20 @@ final class UpgradeV7ToV8 extends Command
      */
     public function handle(): void
     {
-        $this->dbChangeReactionType();
-        $this->dbChangeReaction();
-        // TODO: Remove `reactant_reaction_counters.count` default value
-        // TODO: Remove `reactant_reaction_counters.weight` default value
-        // TODO: Remove `reactant_reaction_totals.count` default value
-        // TODO: Remove `reactant_reaction_totals.weight` default value
+        $this->dbChangeReactionTypes();
+        $this->dbChangeReactions();
+        $this->dbChangeReactantReactionCounters();
+        $this->dbChangeReactantReactionTotals();
     }
 
-    private function dbChangeReactionType(): void
+    private function dbChangeReactionTypes(): void
     {
         $this->getDbSchema()->table('love_reaction_types', function (Blueprint $table) {
             $table->renameColumn('weight', 'mass');
         });
     }
 
-    private function dbChangeReaction(): void
+    private function dbChangeReactions(): void
     {
         $this->getDbSchema()->table('love_reactions', function (Blueprint $table) {
             $table->decimal('rate', 4, 2)->after('reaction_type_id');
@@ -72,6 +70,22 @@ final class UpgradeV7ToV8 extends Command
             ->update([
                 'rate' => 1.0,
             ]);
+    }
+
+    private function dbChangeReactantReactionCounters(): void
+    {
+        $this->getDbSchema()->table('love_reactant_reaction_counters', function (Blueprint $table) {
+            $table->unsignedBigInteger('count')->default(null)->change();
+            $table->decimal('weight', 22, 2)->default(null)->change();
+        });
+    }
+
+    private function dbChangeReactantReactionTotals(): void
+    {
+        $this->getDbSchema()->table('love_reactant_reaction_totals', function (Blueprint $table) {
+            $table->unsignedBigInteger('count')->default(null)->change();
+            $table->decimal('weight', 22, 2)->default(null)->change();
+        });
     }
 
     private function getDbSchema(): Builder

--- a/src/Console/Commands/UpgradeV7ToV8.php
+++ b/src/Console/Commands/UpgradeV7ToV8.php
@@ -43,6 +43,7 @@ final class UpgradeV7ToV8 extends Command
     public function handle(): void
     {
         $this->dbChangeReactionType();
+        $this->dbChangeReaction();
         // TODO: Remove `reactant_reaction_counters.count` default value
         // TODO: Remove `reactant_reaction_counters.weight` default value
         // TODO: Remove `reactant_reaction_totals.count` default value
@@ -53,6 +54,13 @@ final class UpgradeV7ToV8 extends Command
     {
         $this->getDbSchema()->table('love_reaction_types', function (Blueprint $table) {
             $table->renameColumn('weight', 'mass');
+        });
+    }
+
+    private function dbChangeReaction(): void
+    {
+        $this->getDbSchema()->table('love_reactions', function (Blueprint $table) {
+            $table->decimal('rate', 4, 2)->after('reaction_type_id');
         });
     }
 

--- a/src/Console/Commands/UpgradeV7ToV8.php
+++ b/src/Console/Commands/UpgradeV7ToV8.php
@@ -51,7 +51,7 @@ final class UpgradeV7ToV8 extends Command
 
     private function dbChangeReactionType(): void
     {
-        $this->getDbSchema()->table('reaction_types', function (Blueprint $table) {
+        $this->getDbSchema()->table('love_reaction_types', function (Blueprint $table) {
             $table->renameColumn('weight', 'mass');
         });
     }

--- a/src/Console/Commands/UpgradeV7ToV8.php
+++ b/src/Console/Commands/UpgradeV7ToV8.php
@@ -76,7 +76,7 @@ final class UpgradeV7ToV8 extends Command
     {
         $this->getDbSchema()->table('love_reactant_reaction_counters', function (Blueprint $table) {
             $table->unsignedBigInteger('count')->default(null)->change();
-            $table->decimal('weight', 22, 2)->default(null)->change();
+            $table->decimal('weight', 13, 2)->default(null)->change();
         });
     }
 
@@ -84,7 +84,7 @@ final class UpgradeV7ToV8 extends Command
     {
         $this->getDbSchema()->table('love_reactant_reaction_totals', function (Blueprint $table) {
             $table->unsignedBigInteger('count')->default(null)->change();
-            $table->decimal('weight', 22, 2)->default(null)->change();
+            $table->decimal('weight', 13, 2)->default(null)->change();
         });
     }
 

--- a/src/Console/Commands/UpgradeV7ToV8.php
+++ b/src/Console/Commands/UpgradeV7ToV8.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace Cog\Laravel\Love\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 final class UpgradeV7ToV8 extends Command
@@ -62,10 +64,23 @@ final class UpgradeV7ToV8 extends Command
         $this->getDbSchema()->table('love_reactions', function (Blueprint $table) {
             $table->decimal('rate', 4, 2)->after('reaction_type_id');
         });
+
+        $this
+            ->getDbQuery()
+            ->table('love_reactions')
+            ->where('rate', 0.0)
+            ->update([
+                'rate' => 1.0,
+            ]);
     }
 
     private function getDbSchema(): Builder
     {
         return Schema::connection(Config::get('love.storage.database.connection'));
+    }
+
+    private function getDbQuery(): ConnectionInterface
+    {
+        return DB::connection(Config::get('love.storage.database.connection'));
     }
 }

--- a/src/LoveServiceProvider.php
+++ b/src/LoveServiceProvider.php
@@ -18,6 +18,7 @@ use Cog\Laravel\Love\Console\Commands\Recount;
 use Cog\Laravel\Love\Console\Commands\SetupReactable;
 use Cog\Laravel\Love\Console\Commands\SetupReacterable;
 use Cog\Laravel\Love\Console\Commands\UpgradeV5ToV6;
+use Cog\Laravel\Love\Console\Commands\UpgradeV7ToV8;
 use Cog\Laravel\Love\Reactant\Listeners\DecrementAggregates;
 use Cog\Laravel\Love\Reactant\Listeners\IncrementAggregates;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
@@ -94,6 +95,7 @@ final class LoveServiceProvider extends ServiceProvider
                 SetupReactable::class,
                 SetupReacterable::class,
                 UpgradeV5ToV6::class,
+                UpgradeV7ToV8::class,
             ]);
         }
     }

--- a/src/Reactant/Facades/Reactant.php
+++ b/src/Reactant/Facades/Reactant.php
@@ -54,25 +54,29 @@ final class Reactant implements ReacterFacadeContract
 
     public function isReactedBy(
         ReacterableContract $reacterable,
-        ?string $reactionTypeName = null
+        ?string $reactionTypeName = null,
+        ?float $rate = null
     ): bool {
         $reactionType = is_null($reactionTypeName) ? null : ReactionType::fromName($reactionTypeName);
 
         return $this->reactant->isReactedBy(
             $reacterable->getLoveReacter(),
-            $reactionType
+            $reactionType,
+            $rate
         );
     }
 
     public function isNotReactedBy(
         ReacterableContract $reacterable,
-        ?string $reactionTypeName = null
+        ?string $reactionTypeName = null,
+        ?float $rate = null
     ): bool {
         $reactionType = is_null($reactionTypeName) ? null : ReactionType::fromName($reactionTypeName);
 
         return $this->reactant->isNotReactedBy(
             $reacterable->getLoveReacter(),
-            $reactionType
+            $reactionType,
+            $rate
         );
     }
 }

--- a/src/Reactant/Models/NullReactant.php
+++ b/src/Reactant/Models/NullReactant.php
@@ -69,14 +69,16 @@ final class NullReactant implements
 
     public function isReactedBy(
         ReacterContract $reacter,
-        ?ReactionTypeContract $reactionType = null
+        ?ReactionTypeContract $reactionType = null,
+        ?float $rate = null
     ): bool {
         return false;
     }
 
     public function isNotReactedBy(
         ReacterContract $reacter,
-        ?ReactionTypeContract $reactionType = null
+        ?ReactionTypeContract $reactionType = null,
+        ?float $rate = null
     ): bool {
         return true;
     }

--- a/src/Reactant/Models/Reactant.php
+++ b/src/Reactant/Models/Reactant.php
@@ -182,8 +182,6 @@ final class Reactant extends Model implements
 
         $this->reactionCounters()->create([
             'reaction_type_id' => $reactionType->getId(),
-            'count' => 0,
-            'weight' => 0,
         ]);
 
         // Need to reload relation with fresh data
@@ -196,10 +194,7 @@ final class Reactant extends Model implements
             throw ReactionTotalDuplicate::forReactant($this);
         }
 
-        $this->reactionTotal()->create([
-            'count' => 0,
-            'weight' => 0,
-        ]);
+        $this->reactionTotal()->create();
 
         // Need to reload relation with fresh data
         $this->load('reactionTotal');

--- a/src/Reactant/Models/Reactant.php
+++ b/src/Reactant/Models/Reactant.php
@@ -117,7 +117,8 @@ final class Reactant extends Model implements
 
     public function isReactedBy(
         ReacterContract $reacter,
-        ?ReactionTypeContract $reactionType = null
+        ?ReactionTypeContract $reactionType = null,
+        ?float $rate = null
     ): bool {
         if ($reacter->isNull()) {
             return false;
@@ -127,10 +128,20 @@ final class Reactant extends Model implements
         if ($this->relationLoaded('reactions')) {
             return $this
                 ->getAttribute('reactions')
-                ->contains(function (ReactionContract $reaction) use ($reacter, $reactionType) {
-                    return is_null($reactionType)
-                        ? $reaction->isByReacter($reacter)
-                        : $reaction->isByReacter($reacter) && $reaction->isOfType($reactionType);
+                ->contains(function (ReactionContract $reaction) use ($reacter, $reactionType, $rate) {
+                    if ($reaction->isNotByReacter($reacter)) {
+                        return false;
+                    }
+
+                    if (!is_null($reactionType) && $reaction->isNotOfType($reactionType)) {
+                        return false;
+                    }
+
+                    if (!is_null($rate) && $reaction->getRate() !== $rate) {
+                        return false;
+                    }
+
+                    return true;
                 });
         }
 
@@ -140,14 +151,19 @@ final class Reactant extends Model implements
             $query->where('reaction_type_id', $reactionType->getId());
         }
 
+        if (!is_null($rate)) {
+            $query->where('rate', $rate);
+        }
+
         return $query->exists();
     }
 
     public function isNotReactedBy(
         ReacterContract $reacter,
-        ?ReactionTypeContract $reactionType = null
+        ?ReactionTypeContract $reactionType = null,
+        ?float $rate = null
     ): bool {
-        return !$this->isReactedBy($reacter, $reactionType);
+        return !$this->isReactedBy($reacter, $reactionType, $rate);
     }
 
     public function isEqualTo(

--- a/src/Reactant/ReactionCounter/Models/NullReactionCounter.php
+++ b/src/Reactant/ReactionCounter/Models/NullReactionCounter.php
@@ -60,9 +60,9 @@ final class NullReactionCounter implements
         return 0;
     }
 
-    public function getWeight(): int
+    public function getWeight(): float
     {
-        return 0;
+        return 0.0;
     }
 
     public function incrementCount(
@@ -78,13 +78,13 @@ final class NullReactionCounter implements
     }
 
     public function incrementWeight(
-        int $amount
+        float $amount
     ): void {
         throw ReactionCounterInvalid::notExists();
     }
 
     public function decrementWeight(
-        int $amount
+        float $amount
     ): void {
         throw ReactionCounterInvalid::notExists();
     }

--- a/src/Reactant/ReactionCounter/Models/ReactionCounter.php
+++ b/src/Reactant/ReactionCounter/Models/ReactionCounter.php
@@ -24,15 +24,15 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 final class ReactionCounter extends Model implements
     ReactionCounterContract
 {
-    const DEFAULT_COUNT = 0;
+    public const COUNT_DEFAULT = 0;
 
-    const DEFAULT_WEIGHT = 0.0;
+    public const WEIGHT_DEFAULT = 0.0;
 
     protected $table = 'love_reactant_reaction_counters';
 
     protected $attributes = [
-        'count' => self::DEFAULT_COUNT,
-        'weight' => self::DEFAULT_WEIGHT,
+        'count' => self::COUNT_DEFAULT,
+        'weight' => self::WEIGHT_DEFAULT,
     ];
 
     protected $fillable = [

--- a/src/Reactant/ReactionCounter/Models/ReactionCounter.php
+++ b/src/Reactant/ReactionCounter/Models/ReactionCounter.php
@@ -26,7 +26,7 @@ final class ReactionCounter extends Model implements
 {
     const DEFAULT_COUNT = 0;
 
-    const DEFAULT_WEIGHT = 0;
+    const DEFAULT_WEIGHT = 0.0;
 
     protected $table = 'love_reactant_reaction_counters';
 
@@ -43,7 +43,7 @@ final class ReactionCounter extends Model implements
 
     protected $casts = [
         'count' => 'integer',
-        'weight' => 'integer',
+        'weight' => 'float',
     ];
 
     public function reactant(): BelongsTo
@@ -83,7 +83,7 @@ final class ReactionCounter extends Model implements
         return $this->getAttributeValue('count');
     }
 
-    public function getWeight(): int
+    public function getWeight(): float
     {
         return $this->getAttributeValue('weight');
     }
@@ -101,13 +101,13 @@ final class ReactionCounter extends Model implements
     }
 
     public function incrementWeight(
-        int $amount
+        float $amount
     ): void {
         $this->increment('weight', $amount);
     }
 
     public function decrementWeight(
-        int $amount
+        float $amount
     ): void {
         $this->decrement('weight', $amount);
     }

--- a/src/Reactant/ReactionCounter/Observers/ReactionCounterObserver.php
+++ b/src/Reactant/ReactionCounter/Observers/ReactionCounterObserver.php
@@ -21,11 +21,11 @@ final class ReactionCounterObserver
         ReactionCounter $counter
     ): void {
         if (is_null($counter->getAttributeValue('count'))) {
-            $counter->setAttribute('count', ReactionCounter::DEFAULT_COUNT);
+            $counter->setAttribute('count', ReactionCounter::COUNT_DEFAULT);
         }
 
         if (is_null($counter->getAttributeValue('weight'))) {
-            $counter->setAttribute('weight', ReactionCounter::DEFAULT_WEIGHT);
+            $counter->setAttribute('weight', ReactionCounter::WEIGHT_DEFAULT);
         }
     }
 }

--- a/src/Reactant/ReactionTotal/Models/NullReactionTotal.php
+++ b/src/Reactant/ReactionTotal/Models/NullReactionTotal.php
@@ -38,9 +38,9 @@ final class NullReactionTotal implements
         return 0;
     }
 
-    public function getWeight(): int
+    public function getWeight(): float
     {
-        return 0;
+        return 0.0;
     }
 
     public function incrementCount(
@@ -56,13 +56,13 @@ final class NullReactionTotal implements
     }
 
     public function incrementWeight(
-        int $amount
+        float $amount
     ): void {
         throw ReactionTotalInvalid::notExists();
     }
 
     public function decrementWeight(
-        int $amount
+        float $amount
     ): void {
         throw ReactionTotalInvalid::notExists();
     }

--- a/src/Reactant/ReactionTotal/Models/ReactionTotal.php
+++ b/src/Reactant/ReactionTotal/Models/ReactionTotal.php
@@ -24,7 +24,7 @@ final class ReactionTotal extends Model implements
 {
     const DEFAULT_COUNT = 0;
 
-    const DEFAULT_WEIGHT = 0;
+    const DEFAULT_WEIGHT = 0.0;
 
     protected $table = 'love_reactant_reaction_totals';
 
@@ -40,7 +40,7 @@ final class ReactionTotal extends Model implements
 
     protected $casts = [
         'count' => 'integer',
-        'weight' => 'integer',
+        'weight' => 'float',
     ];
 
     public function reactant(): BelongsTo
@@ -58,7 +58,7 @@ final class ReactionTotal extends Model implements
         return $this->getAttributeValue('count');
     }
 
-    public function getWeight(): int
+    public function getWeight(): float
     {
         return $this->getAttributeValue('weight');
     }
@@ -76,13 +76,13 @@ final class ReactionTotal extends Model implements
     }
 
     public function incrementWeight(
-        int $amount
+        float $amount
     ): void {
         $this->increment('weight', $amount);
     }
 
     public function decrementWeight(
-        int $amount
+        float $amount
     ): void {
         $this->decrement('weight', $amount);
     }

--- a/src/Reactant/ReactionTotal/Models/ReactionTotal.php
+++ b/src/Reactant/ReactionTotal/Models/ReactionTotal.php
@@ -22,15 +22,15 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 final class ReactionTotal extends Model implements
     ReactionTotalContract
 {
-    const DEFAULT_COUNT = 0;
+    public const COUNT_DEFAULT = 0;
 
-    const DEFAULT_WEIGHT = 0.0;
+    public const WEIGHT_DEFAULT = 0.0;
 
     protected $table = 'love_reactant_reaction_totals';
 
     protected $attributes = [
-        'count' => self::DEFAULT_COUNT,
-        'weight' => self::DEFAULT_WEIGHT,
+        'count' => self::COUNT_DEFAULT,
+        'weight' => self::WEIGHT_DEFAULT,
     ];
 
     protected $fillable = [

--- a/src/Reactant/ReactionTotal/Observers/ReactionTotalObserver.php
+++ b/src/Reactant/ReactionTotal/Observers/ReactionTotalObserver.php
@@ -21,11 +21,11 @@ final class ReactionTotalObserver
         ReactionTotal $total
     ): void {
         if (is_null($total->getAttributeValue('count'))) {
-            $total->setAttribute('count', ReactionTotal::DEFAULT_COUNT);
+            $total->setAttribute('count', ReactionTotal::COUNT_DEFAULT);
         }
 
         if (is_null($total->getAttributeValue('weight'))) {
-            $total->setAttribute('weight', ReactionTotal::DEFAULT_WEIGHT);
+            $total->setAttribute('weight', ReactionTotal::WEIGHT_DEFAULT);
         }
     }
 }

--- a/src/Reacter/Facades/Reacter.php
+++ b/src/Reacter/Facades/Reacter.php
@@ -56,25 +56,29 @@ final class Reacter implements ReacterFacadeContract
 
     public function hasReactedTo(
         ReactableContract $reactable,
-        ?string $reactionTypeName = null
+        ?string $reactionTypeName = null,
+        ?float $rate = null
     ): bool {
         $reactionType = is_null($reactionTypeName) ? null : ReactionType::fromName($reactionTypeName);
 
         return $this->reacter->hasReactedTo(
             $reactable->getLoveReactant(),
-            $reactionType
+            $reactionType,
+            $rate
         );
     }
 
     public function hasNotReactedTo(
         ReactableContract $reactable,
-        ?string $reactionTypeName = null
+        ?string $reactionTypeName = null,
+        ?float $rate = null
     ): bool {
         $reactionType = is_null($reactionTypeName) ? null : ReactionType::fromName($reactionTypeName);
 
         return $this->reacter->hasNotReactedTo(
             $reactable->getLoveReactant(),
-            $reactionType
+            $reactionType,
+            $rate
         );
     }
 }

--- a/src/Reacter/Facades/Reacter.php
+++ b/src/Reacter/Facades/Reacter.php
@@ -34,11 +34,13 @@ final class Reacter implements ReacterFacadeContract
 
     public function reactTo(
         ReactableContract $reactable,
-        string $reactionTypeName
+        string $reactionTypeName,
+        ?float $rate = null
     ): void {
         $this->reacter->reactTo(
             $reactable->getLoveReactant(),
-            ReactionType::fromName($reactionTypeName)
+            ReactionType::fromName($reactionTypeName),
+            $rate
         );
     }
 

--- a/src/Reacter/Models/NullReacter.php
+++ b/src/Reacter/Models/NullReacter.php
@@ -64,14 +64,16 @@ final class NullReacter implements
 
     public function hasReactedTo(
         Reactant $reactant,
-        ?ReactionType $reactionType = null
+        ?ReactionType $reactionType = null,
+        float $rate = null
     ): bool {
         return false;
     }
 
     public function hasNotReactedTo(
         Reactant $reactant,
-        ?ReactionType $reactionType = null
+        ?ReactionType $reactionType = null,
+        float $rate = null
     ): bool {
         return true;
     }

--- a/src/Reacter/Models/NullReacter.php
+++ b/src/Reacter/Models/NullReacter.php
@@ -49,7 +49,8 @@ final class NullReacter implements
 
     public function reactTo(
         Reactant $reactant,
-        ReactionType $reactionType
+        ReactionType $reactionType,
+        ?float $rate = null
     ): void {
         throw ReacterInvalid::notExists();
     }

--- a/src/Reacter/Models/Reacter.php
+++ b/src/Reacter/Models/Reacter.php
@@ -94,8 +94,7 @@ final class Reacter extends Model implements
             );
         }
 
-        // TODO: Get or compare rate value using reaction contract
-        if ($reaction->getAttributeValue('rate') === $rate) {
+        if ($reaction->getRate() === $rate) {
             throw new ReactionAlreadyExists(
                 sprintf('Reaction of type `%s` with `%s` rate already exists.', $reactionType->getName(), $rate)
             );

--- a/src/Reacter/Models/Reacter.php
+++ b/src/Reacter/Models/Reacter.php
@@ -88,8 +88,14 @@ final class Reacter extends Model implements
             return;
         }
 
+        if (is_null($rate)) {
+            throw new ReactionAlreadyExists(
+                sprintf('Reaction of type `%s` already exists.', $reactionType->getName())
+            );
+        }
+
         // TODO: Get or compare rate value using reaction contract
-        if (is_null($rate) || $reaction->getAttributeValue('rate') === $rate) {
+        if ($reaction->getAttributeValue('rate') === $rate) {
             throw new ReactionAlreadyExists(
                 sprintf('Reaction of type `%s` with `%s` rate already exists.', $reactionType->getName(), $rate)
             );

--- a/src/Reacter/Models/Reacter.php
+++ b/src/Reacter/Models/Reacter.php
@@ -83,11 +83,7 @@ final class Reacter extends Model implements
         $reaction = $this->findReaction($reactant, $reactionType);
 
         if (is_null($reaction)) {
-            $this->reactions()->create([
-                'reaction_type_id' => $reactionType->getId(),
-                'reactant_id' => $reactant->getId(),
-                'rate' => $rate,
-            ]);
+            $this->createReaction($reactant, $reactionType, $rate);
 
             return;
         }
@@ -95,7 +91,7 @@ final class Reacter extends Model implements
         // TODO: Get or compare rate value using reaction contract
         if (is_null($rate) || $reaction->getAttributeValue('rate') === $rate) {
             throw new ReactionAlreadyExists(
-                sprintf('Reaction of type `%s` already exists.', $reactionType->getName())
+                sprintf('Reaction of type `%s` with `%s` rate already exists.', $reactionType->getName(), $rate)
             );
         }
 
@@ -162,6 +158,18 @@ final class Reacter extends Model implements
     public function isNotNull(): bool
     {
         return $this->exists;
+    }
+
+    private function createReaction(
+        ReactantContract $reactant,
+        ReactionTypeContract $reactionType,
+        ?float $rate
+    ): void {
+        $this->reactions()->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => $rate,
+        ]);
     }
 
     /**

--- a/src/Reacter/Models/Reacter.php
+++ b/src/Reacter/Models/Reacter.php
@@ -80,15 +80,26 @@ final class Reacter extends Model implements
             throw ReactantInvalid::notExists();
         }
 
-        if ($this->hasReactedTo($reactant, $reactionType)) {
+        $reaction = $this->findReaction($reactant, $reactionType);
+
+        if (is_null($reaction)) {
+            $this->reactions()->create([
+                'reaction_type_id' => $reactionType->getId(),
+                'reactant_id' => $reactant->getId(),
+                'rate' => $rate,
+            ]);
+
+            return;
+        }
+
+        // TODO: Get or compare rate value using reaction contract
+        if (is_null($rate) || $reaction->getAttributeValue('rate') === $rate) {
             throw new ReactionAlreadyExists(
                 sprintf('Reaction of type `%s` already exists.', $reactionType->getName())
             );
         }
 
-        $this->reactions()->create([
-            'reaction_type_id' => $reactionType->getId(),
-            'reactant_id' => $reactant->getId(),
+        $reaction->update([
             'rate' => $rate,
         ]);
     }

--- a/src/Reacter/Models/Reacter.php
+++ b/src/Reacter/Models/Reacter.php
@@ -126,20 +126,22 @@ final class Reacter extends Model implements
 
     public function hasReactedTo(
         ReactantContract $reactant,
-        ?ReactionTypeContract $reactionType = null
+        ?ReactionTypeContract $reactionType = null,
+        float $rate = null
     ): bool {
         if ($reactant->isNull()) {
             return false;
         }
 
-        return $reactant->isReactedBy($this, $reactionType);
+        return $reactant->isReactedBy($this, $reactionType, $rate);
     }
 
     public function hasNotReactedTo(
         ReactantContract $reactant,
-        ?ReactionTypeContract $reactionType = null
+        ?ReactionTypeContract $reactionType = null,
+        float $rate = null
     ): bool {
-        return $reactant->isNotReactedBy($this, $reactionType);
+        return $reactant->isNotReactedBy($this, $reactionType, $rate);
     }
 
     public function isEqualTo(

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -91,9 +91,9 @@ final class Reaction extends Model implements
     }
 
     public function setRateAttribute(
-        float $amount
+        ?float $amount
     ): void {
-        if ($amount <= 0 || $amount >= 100) {
+        if (!is_null($amount) && ($amount <= 0 || $amount >= 100)) {
             throw new \OutOfRangeException();
         }
 

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -27,16 +27,16 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 final class Reaction extends Model implements
     ReactionContract
 {
-    const DEFAULT_RATE = 1.0;
+    public const RATE_DEFAULT = 1.0;
 
-    const MIN_RATE = 0.01;
+    public const RATE_MIN = 0.01;
 
-    const MAX_RATE = 99.99;
+    public const RATE_MAX = 99.99;
 
     protected $table = 'love_reactions';
 
     protected $attributes = [
-        'rate' => self::DEFAULT_RATE,
+        'rate' => self::RATE_DEFAULT,
     ];
 
     protected $fillable = [
@@ -98,7 +98,7 @@ final class Reaction extends Model implements
     public function setRateAttribute(
         ?float $rate
     ): void {
-        if (!is_null($rate) && ($rate < self::MIN_RATE || $rate > self::MAX_RATE)) {
+        if (!is_null($rate) && ($rate < self::RATE_MIN || $rate > self::RATE_MAX)) {
             throw RateValueInvalid::withValue($rate);
         }
 

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -15,6 +15,7 @@ namespace Cog\Laravel\Love\Reaction\Models;
 
 use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
 use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
+use Cog\Contracts\Love\Reaction\Exceptions\RateValueInvalid;
 use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
 use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
@@ -27,6 +28,10 @@ final class Reaction extends Model implements
     ReactionContract
 {
     const DEFAULT_RATE = 1.0;
+
+    const MIN_RATE = 0.01;
+
+    const MAX_RATE = 99.99;
 
     protected $table = 'love_reactions';
 
@@ -91,13 +96,13 @@ final class Reaction extends Model implements
     }
 
     public function setRateAttribute(
-        ?float $amount
+        ?float $rate
     ): void {
-        if (!is_null($amount) && ($amount <= 0 || $amount >= 100)) {
-            throw new \OutOfRangeException();
+        if (!is_null($rate) && ($rate < self::MIN_RATE || $rate > self::MAX_RATE)) {
+            throw RateValueInvalid::withValue($rate);
         }
 
-        $this->attributes['rate'] = $amount;
+        $this->attributes['rate'] = $rate;
     }
 
     public function isOfType(

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -80,9 +80,14 @@ final class Reaction extends Model implements
         return $this->getAttribute('type');
     }
 
+    public function getRate(): float
+    {
+        return $this->getAttributeValue('rate');
+    }
+
     public function getWeight(): float
     {
-        return $this->getType()->getMass() * $this->getAttributeValue('rate');
+        return $this->getType()->getMass() * $this->getRate();
     }
 
     public function isOfType(

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -26,15 +26,23 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 final class Reaction extends Model implements
     ReactionContract
 {
+    const DEFAULT_RATE = 1.0;
+
     protected $table = 'love_reactions';
+
+    protected $attributes = [
+        'rate' => self::DEFAULT_RATE,
+    ];
 
     protected $fillable = [
         'reactant_id',
         'reaction_type_id',
+        'rate',
     ];
 
     protected $casts = [
         'id' => 'string',
+        'rate' => 'float',
     ];
 
     public function reactant(): BelongsTo

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -15,7 +15,7 @@ namespace Cog\Laravel\Love\Reaction\Models;
 
 use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
 use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
-use Cog\Contracts\Love\Reaction\Exceptions\RateValueInvalid;
+use Cog\Contracts\Love\Reaction\Exceptions\RateOutOfRange;
 use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
 use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
@@ -99,7 +99,7 @@ final class Reaction extends Model implements
         ?float $rate
     ): void {
         if (!is_null($rate) && ($rate < self::RATE_MIN || $rate > self::RATE_MAX)) {
-            throw RateValueInvalid::withValue($rate);
+            throw RateOutOfRange::withValue($rate);
         }
 
         $this->attributes['rate'] = $rate;

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -80,9 +80,9 @@ final class Reaction extends Model implements
         return $this->getAttribute('type');
     }
 
-    public function getWeight(): int
+    public function getWeight(): float
     {
-        return $this->getType()->getMass();
+        return $this->getType()->getMass() * $this->getAttributeValue('rate');
     }
 
     public function isOfType(

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -90,6 +90,16 @@ final class Reaction extends Model implements
         return $this->getType()->getMass() * $this->getRate();
     }
 
+    public function setRateAttribute(
+        float $amount
+    ): void {
+        if ($amount <= 0 || $amount >= 100) {
+            throw new \OutOfRangeException();
+        }
+
+        $this->attributes['rate'] = $amount;
+    }
+
     public function isOfType(
         ReactionTypeContract $reactionType
     ): bool {

--- a/src/Reaction/Observers/ReactionObserver.php
+++ b/src/Reaction/Observers/ReactionObserver.php
@@ -23,7 +23,7 @@ final class ReactionObserver
         Reaction $reaction
     ): void {
         if (is_null($reaction->getAttributeValue('rate'))) {
-            $reaction->setAttribute('rate', Reaction::DEFAULT_RATE);
+            $reaction->setAttribute('rate', Reaction::RATE_DEFAULT);
         }
     }
 

--- a/src/Reaction/Observers/ReactionObserver.php
+++ b/src/Reaction/Observers/ReactionObserver.php
@@ -19,6 +19,14 @@ use Cog\Laravel\Love\Reaction\Models\Reaction;
 
 final class ReactionObserver
 {
+    public function creating(
+        Reaction $reaction
+    ): void {
+        if (is_null($reaction->getAttributeValue('rate'))) {
+            $reaction->setAttribute('rate', Reaction::DEFAULT_RATE);
+        }
+    }
+
     public function created(
         Reaction $reaction
     ): void {

--- a/src/ReactionType/Models/ReactionType.php
+++ b/src/ReactionType/Models/ReactionType.php
@@ -22,10 +22,12 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 final class ReactionType extends Model implements
     ReactionTypeContract
 {
+    const DEFAULT_MASS = 0;
+
     protected $table = 'love_reaction_types';
 
     protected $attributes = [
-        'mass' => 0,
+        'mass' => self::DEFAULT_MASS,
     ];
 
     protected $fillable = [

--- a/src/ReactionType/Models/ReactionType.php
+++ b/src/ReactionType/Models/ReactionType.php
@@ -22,12 +22,12 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 final class ReactionType extends Model implements
     ReactionTypeContract
 {
-    const DEFAULT_MASS = 0;
+    public const MASS_DEFAULT = 0;
 
     protected $table = 'love_reaction_types';
 
     protected $attributes = [
-        'mass' => self::DEFAULT_MASS,
+        'mass' => self::MASS_DEFAULT,
     ];
 
     protected $fillable = [

--- a/tests/Unit/Console/Commands/ReactionTypeAddTest.php
+++ b/tests/Unit/Console/Commands/ReactionTypeAddTest.php
@@ -197,18 +197,16 @@ final class ReactionTypeAddTest extends TestCase
     }
 
     /** @test */
-    public function it_repeat_ask_for_name_if_name_question_not_answered(): void
+    public function it_throws_error_if_name_question_answered_with_null(): void
     {
         $typesCount = ReactionType::query()->count();
         $this
             ->artisan('love:reaction-type-add', ['--mass' => '4'])
             ->expectsQuestion('How to name reaction type?', null)
-            ->expectsQuestion('How to name reaction type?', 'TestName')
-            ->assertExitCode(0);
+            ->expectsOutput('Reaction type with name `` is invalid.')
+            ->assertExitCode(1);
 
-        $this->assertSame($typesCount + 1, ReactionType::query()->count());
-        $reactionType = ReactionType::query()->latest()->first();
-        $this->assertSame('TestName', $reactionType->getName());
+        $this->assertSame($typesCount, ReactionType::query()->count());
     }
 
     /** @test */

--- a/tests/Unit/Console/Commands/ReactionTypeAddTest.php
+++ b/tests/Unit/Console/Commands/ReactionTypeAddTest.php
@@ -237,7 +237,7 @@ final class ReactionTypeAddTest extends TestCase
     }
 
     /** @test */
-    public function it_creates_type_with_zero_mass_if_not_answered(): void
+    public function it_creates_type_with_default_mass_if_not_answered(): void
     {
         $typesCount = ReactionType::query()->count();
         $this
@@ -247,7 +247,7 @@ final class ReactionTypeAddTest extends TestCase
 
         $this->assertSame($typesCount + 1, ReactionType::query()->count());
         $reactionType = ReactionType::query()->latest()->first();
-        $this->assertSame(0, $reactionType->getMass());
+        $this->assertSame(ReactionType::DEFAULT_MASS, $reactionType->getMass());
     }
 
     /** @test */

--- a/tests/Unit/Console/Commands/ReactionTypeAddTest.php
+++ b/tests/Unit/Console/Commands/ReactionTypeAddTest.php
@@ -247,7 +247,7 @@ final class ReactionTypeAddTest extends TestCase
 
         $this->assertSame($typesCount + 1, ReactionType::query()->count());
         $reactionType = ReactionType::query()->latest()->first();
-        $this->assertSame(ReactionType::DEFAULT_MASS, $reactionType->getMass());
+        $this->assertSame(ReactionType::MASS_DEFAULT, $reactionType->getMass());
     }
 
     /** @test */

--- a/tests/Unit/Console/Commands/RecountTest.php
+++ b/tests/Unit/Console/Commands/RecountTest.php
@@ -71,26 +71,26 @@ final class RecountTest extends TestCase
         $this->assertReactantLikesCount($reactant2, 2);
         $this->assertReactantLikesCount($reactant3, 2);
         $this->assertReactantLikesCount($reactant4, 1);
-        $this->assertReactantLikesWeight($reactant1, 6);
-        $this->assertReactantLikesWeight($reactant2, 4);
-        $this->assertReactantLikesWeight($reactant3, 4);
-        $this->assertReactantLikesWeight($reactant4, 2);
+        $this->assertReactantLikesWeight($reactant1, 6.0);
+        $this->assertReactantLikesWeight($reactant2, 4.0);
+        $this->assertReactantLikesWeight($reactant3, 4.0);
+        $this->assertReactantLikesWeight($reactant4, 2.0);
         $this->assertReactantDislikesCount($reactant1, 0);
         $this->assertReactantDislikesCount($reactant2, 0);
         $this->assertReactantDislikesCount($reactant3, 0);
         $this->assertReactantDislikesCount($reactant1, 0);
-        $this->assertReactantDislikesWeight($reactant1, 0);
-        $this->assertReactantDislikesWeight($reactant2, 0);
-        $this->assertReactantDislikesWeight($reactant3, 0);
-        $this->assertReactantDislikesWeight($reactant4, 0);
+        $this->assertReactantDislikesWeight($reactant1, 0.0);
+        $this->assertReactantDislikesWeight($reactant2, 0.0);
+        $this->assertReactantDislikesWeight($reactant3, 0.0);
+        $this->assertReactantDislikesWeight($reactant4, 0.0);
         $this->assertReactantTotalCount($reactant1, 3);
         $this->assertReactantTotalCount($reactant2, 2);
         $this->assertReactantTotalCount($reactant3, 2);
         $this->assertReactantTotalCount($reactant4, 1);
-        $this->assertReactantTotalWeight($reactant1, 6);
-        $this->assertReactantTotalWeight($reactant2, 4);
-        $this->assertReactantTotalWeight($reactant3, 4);
-        $this->assertReactantTotalWeight($reactant4, 2);
+        $this->assertReactantTotalWeight($reactant1, 6.0);
+        $this->assertReactantTotalWeight($reactant2, 4.0);
+        $this->assertReactantTotalWeight($reactant3, 4.0);
+        $this->assertReactantTotalWeight($reactant4, 2.0);
     }
 
     /** @test */
@@ -831,8 +831,8 @@ final class RecountTest extends TestCase
             'type' => 'Like',
         ]);
 
-        $this->assertSame(0, $reactant1->reactionCounters->first()->weight);
-        $this->assertSame(0, $reactant2->reactionCounters->first()->weight);
+        $this->assertSame(0.0, $reactant1->reactionCounters->first()->weight);
+        $this->assertSame(0.0, $reactant2->reactionCounters->first()->weight);
     }
 
     /** @test */
@@ -902,8 +902,8 @@ final class RecountTest extends TestCase
             'type' => 'Like',
         ]);
 
-        $this->assertSame(0, $reactant1->reactionTotal->weight);
-        $this->assertSame(0, $reactant2->reactionTotal->weight);
+        $this->assertSame(0.0, $reactant1->reactionTotal->weight);
+        $this->assertSame(0.0, $reactant2->reactionTotal->weight);
     }
 
     private function reactionsCount(
@@ -918,7 +918,7 @@ final class RecountTest extends TestCase
     private function reactionsWeight(
         ReactantContract $reactant,
         ReactionTypeContract $reactionType
-    ): int {
+    ): float {
         return $reactant
             ->getReactionCounterOfType($reactionType)
             ->getWeight();
@@ -946,7 +946,7 @@ final class RecountTest extends TestCase
 
     private function assertReactantLikesWeight(
         ReactantContract $reactant,
-        int $count
+        float $count
     ): void {
         $this->assertSame(
             $count,
@@ -956,7 +956,7 @@ final class RecountTest extends TestCase
 
     private function assertReactantDislikesWeight(
         ReactantContract $reactant,
-        int $count
+        float $count
     ): void {
         $this->assertSame(
             $count,
@@ -976,7 +976,7 @@ final class RecountTest extends TestCase
 
     private function assertReactantTotalWeight(
         ReactantContract $reactant,
-        int $count
+        float $count
     ): void {
         $this->assertSame(
             $count,

--- a/tests/Unit/Reactant/Facades/ReactantTest.php
+++ b/tests/Unit/Reactant/Facades/ReactantTest.php
@@ -341,4 +341,190 @@ final class ReactantTest extends TestCase
 
         $this->assertTrue($isNotReacted);
     }
+
+    /** @test */
+    public function it_can_check_is_reacted_by_reacterable_with_rate(): void
+    {
+        $reacterable = factory(User::class)->create();
+        $reacter = $reacterable->getLoveReacter();
+        $reactant = factory(Reactant::class)->create();
+        factory(Reaction::class)->create([
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $isReacted = $reactantFacade->isReactedBy($reacterable, null, 2.0);
+
+        $this->assertTrue($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_reacted_by_reacterable_with_rate_when_reacter_is_null_object(): void
+    {
+        $reacterable = factory(UserWithoutAutoReacterCreate::class)->create();
+        $reactant = factory(Reactant::class)->create();
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $isReacted = $reactantFacade->isReactedBy($reacterable, null, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_reacted_by_reacterable_with_rate_when_reacter_is_not_persisted(): void
+    {
+        $reacterable = new User();
+        $reactant = factory(Reactant::class)->create();
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $isReacted = $reactantFacade->isReactedBy($reacterable, null, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_reacterable_with_rate(): void
+    {
+        $reacterable = factory(User::class)->create();
+        $reacter = $reacterable->getLoveReacter();
+        $reactant = factory(Reactant::class)->create();
+        factory(Reaction::class)->create([
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.2,
+        ]);
+        factory(Reaction::class)->create([
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $isNotReacted = $reactantFacade->isNotReactedBy($reacterable, null, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_reacterable_with_rate_when_reacter_is_null_object(): void
+    {
+        $reacterable = factory(UserWithoutAutoReacterCreate::class)->create();
+        $reactant = factory(Reactant::class)->create();
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $isNotReacted = $reactantFacade->isNotReactedBy($reacterable, null, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_reacterable_with_rate_when_reacter_is_not_persisted(): void
+    {
+        $reacterable = new User();
+        $reactant = factory(Reactant::class)->create();
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $isNotReacted = $reactantFacade->isNotReactedBy($reacterable, null, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_reacted_by_reacterable_with_type_and_rate(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacterable = factory(User::class)->create();
+        $reacter = $reacterable->getLoveReacter();
+        $reactant = factory(Reactant::class)->create();
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $isReacted = $reactantFacade->isReactedBy($reacterable, $reactionType->getName(), 2.0);
+
+        $this->assertTrue($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_reacted_by_reacterable_with_type_and_rate_when_reacter_is_null_object(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacterable = factory(UserWithoutAutoReacterCreate::class)->create();
+        $reactant = factory(Reactant::class)->create();
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $isReacted = $reactantFacade->isReactedBy($reacterable, $reactionType->getName(), 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_reacted_by_reacterable_with_type_and_rate_when_reacter_is_not_persisted(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacterable = new User();
+        $reactant = factory(Reactant::class)->create();
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $isReacted = $reactantFacade->isReactedBy($reacterable, $reactionType->getName(), 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_reacterable_with_type_and_rate(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $otherReactionType = factory(ReactionType::class)->create();
+        $reacterable = factory(User::class)->create();
+        $reacter = $reacterable->getLoveReacter();
+        $reactant = factory(Reactant::class)->create();
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $otherReactionType->getId(),
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.2,
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $isNotReacted = $reactantFacade->isNotReactedBy($reacterable, $reactionType->getName(), 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_reacterable_with_type_and_rate_when_reacter_is_null_object(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacterable = factory(UserWithoutAutoReacterCreate::class)->create();
+        $reactant = factory(Reactant::class)->create();
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $isNotReacted = $reactantFacade->isNotReactedBy($reacterable, $reactionType->getName(), 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_reacterable_with_type_and_rate_when_reacter_is_not_persisted(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacterable = new User();
+        $reactant = factory(Reactant::class)->create();
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $isNotReacted = $reactantFacade->isNotReactedBy($reacterable, $reactionType->getName(), 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
 }

--- a/tests/Unit/Reactant/Models/NullReactantTest.php
+++ b/tests/Unit/Reactant/Models/NullReactantTest.php
@@ -263,6 +263,52 @@ final class NullReactantTest extends TestCase
     }
 
     /** @test */
+    public function it_can_check_is_reacted_by_with_rate(): void
+    {
+        $reactant = new NullReactant(new Article());
+        $reacter = factory(Reacter::class)->make();
+
+        $isReacted = $reactant->isReactedBy($reacter, null, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_with_rate(): void
+    {
+        $reactant = new NullReactant(new Article());
+        $reacter = factory(Reacter::class)->make();
+
+        $isReacted = $reactant->isNotReactedBy($reacter, null, 2.0);
+
+        $this->assertTrue($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_reacted_by_with_type_and_rate(): void
+    {
+        $reactant = new NullReactant(new Article());
+        $reacter = factory(Reacter::class)->make();
+        $reactionType = new ReactionType();
+
+        $isReacted = $reactant->isReactedBy($reacter, $reactionType, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_with_type_and_rate(): void
+    {
+        $reactant = new NullReactant(new Article());
+        $reacter = factory(Reacter::class)->make();
+        $reactionType = new ReactionType();
+
+        $isReacted = $reactant->isNotReactedBy($reacter, $reactionType, 2.0);
+
+        $this->assertTrue($isReacted);
+    }
+
+    /** @test */
     public function it_throws_exception_on_create_reaction_counter_of_type(): void
     {
         $this->expectException(ReactantInvalid::class);

--- a/tests/Unit/Reactant/Models/ReactantTest.php
+++ b/tests/Unit/Reactant/Models/ReactantTest.php
@@ -559,7 +559,7 @@ final class ReactantTest extends TestCase
         $this->assertTrue($counter->isReactionOfType($reactionType));
         $this->assertTrue($counter->getReactant()->is($reactant));
         $this->assertSame(0, $counter->getCount());
-        $this->assertSame(0, $counter->getWeight());
+        $this->assertSame(0.0, $counter->getWeight());
     }
 
     /** @test */
@@ -585,7 +585,7 @@ final class ReactantTest extends TestCase
         $total = $reactant->getReactionTotal();
         $this->assertTrue($total->getReactant()->is($reactant));
         $this->assertSame(0, $total->getCount());
-        $this->assertSame(0, $total->getWeight());
+        $this->assertSame(0.0, $total->getWeight());
     }
 
     /** @test */

--- a/tests/Unit/Reactant/Models/ReactantTest.php
+++ b/tests/Unit/Reactant/Models/ReactantTest.php
@@ -52,6 +52,7 @@ final class ReactantTest extends TestCase
         ]);
 
         $this->assertSame('4', $reactant->getAttribute('id'));
+        $this->assertSame('4', $reactant->getId());
     }
 
     /** @test */

--- a/tests/Unit/Reactant/Models/ReactantTest.php
+++ b/tests/Unit/Reactant/Models/ReactantTest.php
@@ -476,6 +476,176 @@ final class ReactantTest extends TestCase
     }
 
     /** @test */
+    public function it_can_check_is_reacted_by_reacter_with_rate(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reactant = factory(Reactant::class)->create();
+        factory(Reaction::class)->create([
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+
+        $isReacted = $reactant->isReactedBy($reacter, null, 2.0);
+
+        $this->assertTrue($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_reacted_by_reacter_with_rate_when_reacter_is_null_object(): void
+    {
+        $reacter = new NullReacter(new Bot());
+        $reactant = factory(Reactant::class)->create();
+
+        $isReacted = $reactant->isReactedBy($reacter, null, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_reacted_by_reacter_with_rate_when_reacter_is_not_persisted(): void
+    {
+        $reacter = new Reacter();
+        $reactant = factory(Reactant::class)->create();
+
+        $isReacted = $reactant->isReactedBy($reacter, null, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_reacter_with_rate(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reactant = factory(Reactant::class)->create();
+        factory(Reaction::class)->create([
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 4.2,
+        ]);
+        factory(Reaction::class)->create([
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+
+        $isNotReacted = $reactant->isNotReactedBy($reacter, null, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_reacter_with_rate_when_reacter_is_null_object(): void
+    {
+        $reacter = new NullReacter(new Bot());
+        $reactant = factory(Reactant::class)->create();
+
+        $isNotReacted = $reactant->isNotReactedBy($reacter, null, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_reacter_with_rate_when_reacter_is_not_persisted(): void
+    {
+        $reacter = new Reacter();
+        $reactant = factory(Reactant::class)->create();
+
+        $isNotReacted = $reactant->isNotReactedBy($reacter, null, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_reacted_by_reacter_with_type_and_rate(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactant = factory(Reactant::class)->create();
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+
+        $isReacted = $reactant->isReactedBy($reacter, $reactionType, 2.0);
+
+        $this->assertTrue($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_reacted_by_reacter_with_type_and_rate_when_reacter_is_null_object(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = new NullReacter(new Bot());
+        $reactant = factory(Reactant::class)->create();
+
+        $isReacted = $reactant->isReactedBy($reacter, $reactionType, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_reacted_by_reacter_with_type_and_rate_when_reacter_is_not_persisted(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = new Reacter();
+        $reactant = factory(Reactant::class)->create();
+
+        $isReacted = $reactant->isReactedBy($reacter, $reactionType, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_reacter_with_type_and_rate(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $otherReactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactant = factory(Reactant::class)->create();
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $otherReactionType->getId(),
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.2,
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+
+        $isNotReacted = $reactant->isNotReactedBy($reacter, $reactionType, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_reacter_with_type_and_rate_when_reacter_is_null_object(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = new NullReacter(new Bot());
+        $reactant = factory(Reactant::class)->create();
+
+        $isNotReacted = $reactant->isNotReactedBy($reacter, $reactionType, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_is_not_reacted_by_reacter_with_type_and_rate_when_reacter_is_not_persisted(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = new Reacter();
+        $reactant = factory(Reactant::class)->create();
+
+        $isNotReacted = $reactant->isNotReactedBy($reacter, $reactionType, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
     public function it_can_check_is_equal_to_self(): void
     {
         $reactant = factory(Reactant::class)->create();

--- a/tests/Unit/Reactant/ReactionCounter/Models/NullReactionCounterTest.php
+++ b/tests/Unit/Reactant/ReactionCounter/Models/NullReactionCounterTest.php
@@ -41,7 +41,7 @@ final class NullReactionCounterTest extends TestCase
 
         $counterWeight = $counter->getWeight();
 
-        $this->assertSame(0, $counterWeight);
+        $this->assertSame(0.0, $counterWeight);
     }
 
     /** @test */

--- a/tests/Unit/Reactant/ReactionCounter/Models/ReactionCounterTest.php
+++ b/tests/Unit/Reactant/ReactionCounter/Models/ReactionCounterTest.php
@@ -38,7 +38,7 @@ final class ReactionCounterTest extends TestCase
             'weight' => 4,
         ]);
 
-        $this->assertSame(4, $counter->getAttribute('weight'));
+        $this->assertSame(4.0, $counter->getAttribute('weight'));
     }
 
     /** @test */
@@ -68,7 +68,7 @@ final class ReactionCounterTest extends TestCase
             'weight' => '4',
         ]);
 
-        $this->assertSame(4, $counter->getAttribute('weight'));
+        $this->assertSame(4.0, $counter->getAttribute('weight'));
     }
 
     /** @test */
@@ -196,7 +196,7 @@ final class ReactionCounterTest extends TestCase
             'weight' => '4',
         ]);
 
-        $this->assertSame(4, $counter->getWeight());
+        $this->assertSame(4.0, $counter->getWeight());
     }
 
     /** @test */
@@ -204,7 +204,7 @@ final class ReactionCounterTest extends TestCase
     {
         $counter = new ReactionCounter();
 
-        $this->assertSame(0, $counter->getWeight());
+        $this->assertSame(0.0, $counter->getWeight());
     }
 
     /** @test */
@@ -266,7 +266,7 @@ final class ReactionCounterTest extends TestCase
 
         $counter->incrementWeight(2);
 
-        $this->assertSame(2, $counter->getWeight());
+        $this->assertSame(2.0, $counter->getWeight());
     }
 
     /** @test */
@@ -279,7 +279,7 @@ final class ReactionCounterTest extends TestCase
         $counter->incrementWeight(2);
         $counter->incrementWeight(3);
 
-        $this->assertSame(5, $counter->getWeight());
+        $this->assertSame(5.0, $counter->getWeight());
     }
 
     /** @test */
@@ -291,7 +291,7 @@ final class ReactionCounterTest extends TestCase
 
         $counter->decrementWeight(2);
 
-        $this->assertSame(8, $counter->getWeight());
+        $this->assertSame(8.0, $counter->getWeight());
     }
 
     /** @test */
@@ -304,6 +304,6 @@ final class ReactionCounterTest extends TestCase
         $counter->decrementWeight(2);
         $counter->decrementWeight(3);
 
-        $this->assertSame(5, $counter->getWeight());
+        $this->assertSame(5.0, $counter->getWeight());
     }
 }

--- a/tests/Unit/Reactant/ReactionCounter/Models/ReactionCounterTest.php
+++ b/tests/Unit/Reactant/ReactionCounter/Models/ReactionCounterTest.php
@@ -59,16 +59,18 @@ final class ReactionCounterTest extends TestCase
         ]);
 
         $this->assertSame(4, $counter->getAttribute('count'));
+        $this->assertSame(4, $counter->getCount());
     }
 
     /** @test */
-    public function it_casts_weight_to_integer(): void
+    public function it_casts_weight_to_float(): void
     {
         $counter = new ReactionCounter([
             'weight' => '4',
         ]);
 
         $this->assertSame(4.0, $counter->getAttribute('weight'));
+        $this->assertSame(4.0, $counter->getWeight());
     }
 
     /** @test */

--- a/tests/Unit/Reactant/ReactionCounter/Observers/ReactionCounterObserverTest.php
+++ b/tests/Unit/Reactant/ReactionCounter/Observers/ReactionCounterObserverTest.php
@@ -25,7 +25,7 @@ final class ReactionCounterObserverTest extends TestCase
             'count' => null,
         ]);
 
-        $this->assertSame(ReactionCounter::DEFAULT_COUNT, $counter->getCount());
+        $this->assertSame(ReactionCounter::COUNT_DEFAULT, $counter->getCount());
     }
 
     /** @test */
@@ -35,6 +35,6 @@ final class ReactionCounterObserverTest extends TestCase
             'weight' => null,
         ]);
 
-        $this->assertSame(ReactionCounter::DEFAULT_WEIGHT, $counter->getWeight());
+        $this->assertSame(ReactionCounter::WEIGHT_DEFAULT, $counter->getWeight());
     }
 }

--- a/tests/Unit/Reactant/ReactionCounter/Services/ReactionCounterServiceTest.php
+++ b/tests/Unit/Reactant/ReactionCounter/Services/ReactionCounterServiceTest.php
@@ -46,7 +46,7 @@ final class ReactionCounterServiceTest extends TestCase
 
         $counter = $reactant->reactionCounters->first();
         $this->assertSame(2, $counter->count);
-        $this->assertSame(8, $counter->weight);
+        $this->assertSame(8.0, $counter->weight);
     }
 
     /** @test */
@@ -78,7 +78,7 @@ final class ReactionCounterServiceTest extends TestCase
 
         $counter->refresh();
         $this->assertSame(2, $counter->count);
-        $this->assertSame(8, $counter->weight);
+        $this->assertSame(8.0, $counter->weight);
     }
 
     /** @test */
@@ -130,7 +130,7 @@ final class ReactionCounterServiceTest extends TestCase
 
         $counter->refresh();
         $this->assertSame(2, $counter->count);
-        $this->assertSame(-8, $counter->weight);
+        $this->assertSame(-8.0, $counter->weight);
     }
 
     /** @test */
@@ -153,7 +153,7 @@ final class ReactionCounterServiceTest extends TestCase
         $this->assertCount(0, $initialCounters);
         $this->assertCount(1, $reactant->reactionCounters);
         $this->assertSame(1, $reactant->reactionCounters->get(0)->count);
-        $this->assertSame(4, $reactant->reactionCounters->get(0)->weight);
+        $this->assertSame(4.0, $reactant->reactionCounters->get(0)->weight);
     }
 
     /** @test */
@@ -177,6 +177,6 @@ final class ReactionCounterServiceTest extends TestCase
         $this->assertCount(0, $initialCounters);
         $this->assertCount(1, $reactant->reactionCounters);
         $this->assertSame(0, $reactant->reactionCounters->get(0)->count);
-        $this->assertSame(0, $reactant->reactionCounters->get(0)->weight);
+        $this->assertSame(0.0, $reactant->reactionCounters->get(0)->weight);
     }
 }

--- a/tests/Unit/Reactant/ReactionTotal/Models/NullReactionTotalTest.php
+++ b/tests/Unit/Reactant/ReactionTotal/Models/NullReactionTotalTest.php
@@ -40,7 +40,7 @@ final class NullReactionTotalTest extends TestCase
 
         $totalWeight = $total->getWeight();
 
-        $this->assertSame(0, $totalWeight);
+        $this->assertSame(0.0, $totalWeight);
     }
 
     /** @test */

--- a/tests/Unit/Reactant/ReactionTotal/Models/ReactionTotalTest.php
+++ b/tests/Unit/Reactant/ReactionTotal/Models/ReactionTotalTest.php
@@ -37,7 +37,7 @@ final class ReactionTotalTest extends TestCase
             'weight' => 4,
         ]);
 
-        $this->assertSame(4, $total->getAttribute('weight'));
+        $this->assertSame(4.0, $total->getAttribute('weight'));
     }
 
     /** @test */
@@ -57,7 +57,7 @@ final class ReactionTotalTest extends TestCase
             'weight' => '4',
         ]);
 
-        $this->assertSame(4, $total->getAttribute('weight'));
+        $this->assertSame(4.0, $total->getAttribute('weight'));
     }
 
     /** @test */
@@ -119,7 +119,7 @@ final class ReactionTotalTest extends TestCase
             'weight' => '4',
         ]);
 
-        $this->assertSame(4, $total->getWeight());
+        $this->assertSame(4.0, $total->getWeight());
     }
 
     /** @test */
@@ -127,7 +127,7 @@ final class ReactionTotalTest extends TestCase
     {
         $total = new ReactionTotal();
 
-        $this->assertSame(0, $total->getWeight());
+        $this->assertSame(0.0, $total->getWeight());
     }
 
     /** @test */
@@ -189,7 +189,7 @@ final class ReactionTotalTest extends TestCase
 
         $total->incrementWeight(2);
 
-        $this->assertSame(2, $total->getWeight());
+        $this->assertSame(2.0, $total->getWeight());
     }
 
     /** @test */
@@ -202,7 +202,7 @@ final class ReactionTotalTest extends TestCase
         $total->incrementWeight(2);
         $total->incrementWeight(3);
 
-        $this->assertSame(5, $total->getWeight());
+        $this->assertSame(5.0, $total->getWeight());
     }
 
     /** @test */
@@ -214,7 +214,7 @@ final class ReactionTotalTest extends TestCase
 
         $total->decrementWeight(2);
 
-        $this->assertSame(8, $total->getWeight());
+        $this->assertSame(8.0, $total->getWeight());
     }
 
     /** @test */
@@ -227,6 +227,6 @@ final class ReactionTotalTest extends TestCase
         $total->decrementWeight(2);
         $total->decrementWeight(3);
 
-        $this->assertSame(5, $total->getWeight());
+        $this->assertSame(5.0, $total->getWeight());
     }
 }

--- a/tests/Unit/Reactant/ReactionTotal/Models/ReactionTotalTest.php
+++ b/tests/Unit/Reactant/ReactionTotal/Models/ReactionTotalTest.php
@@ -48,16 +48,18 @@ final class ReactionTotalTest extends TestCase
         ]);
 
         $this->assertSame(4, $total->getAttribute('count'));
+        $this->assertSame(4, $total->getCount());
     }
 
     /** @test */
-    public function it_casts_weight_to_integer(): void
+    public function it_casts_weight_to_float(): void
     {
         $total = new ReactionTotal([
             'weight' => '4',
         ]);
 
         $this->assertSame(4.0, $total->getAttribute('weight'));
+        $this->assertSame(4.0, $total->getWeight());
     }
 
     /** @test */

--- a/tests/Unit/Reactant/ReactionTotal/Observers/ReactionTotalObserverTest.php
+++ b/tests/Unit/Reactant/ReactionTotal/Observers/ReactionTotalObserverTest.php
@@ -25,7 +25,7 @@ final class ReactionTotalObserverTest extends TestCase
             'count' => null,
         ]);
 
-        $this->assertSame(ReactionTotal::DEFAULT_COUNT, $total->getCount());
+        $this->assertSame(ReactionTotal::COUNT_DEFAULT, $total->getCount());
     }
 
     /** @test */
@@ -35,6 +35,6 @@ final class ReactionTotalObserverTest extends TestCase
             'weight' => null,
         ]);
 
-        $this->assertSame(ReactionTotal::DEFAULT_WEIGHT, $total->getWeight());
+        $this->assertSame(ReactionTotal::WEIGHT_DEFAULT, $total->getWeight());
     }
 }

--- a/tests/Unit/Reactant/ReactionTotal/Services/ReactionTotalServiceTest.php
+++ b/tests/Unit/Reactant/ReactionTotal/Services/ReactionTotalServiceTest.php
@@ -46,7 +46,7 @@ final class ReactionTotalServiceTest extends TestCase
 
         $total = $reactant->reactionTotal;
         $this->assertSame(2, $total->count);
-        $this->assertSame(8, $total->weight);
+        $this->assertSame(8.0, $total->weight);
     }
 
     /** @test */
@@ -76,7 +76,7 @@ final class ReactionTotalServiceTest extends TestCase
         $service->removeReaction($reaction2);
 
         $this->assertSame(2, $total->fresh()->count);
-        $this->assertSame(8, $total->fresh()->weight);
+        $this->assertSame(8.0, $total->fresh()->weight);
     }
 
     /** @test */
@@ -123,7 +123,7 @@ final class ReactionTotalServiceTest extends TestCase
 
         $total = $reactant->reactionTotal;
         $this->assertSame(2, $total->count);
-        $this->assertSame(-8, $total->weight);
+        $this->assertSame(-8.0, $total->weight);
     }
 
     /** @test */
@@ -145,7 +145,7 @@ final class ReactionTotalServiceTest extends TestCase
         $total = $reactant->getReactionTotal();
         $this->assertInstanceOf(ReactionTotal::class, $total);
         $this->assertSame(1, $total->count);
-        $this->assertSame(4, $total->weight);
+        $this->assertSame(4.0, $total->weight);
     }
 
     /** @test */
@@ -165,6 +165,6 @@ final class ReactionTotalServiceTest extends TestCase
         $total = $reactant->getReactionTotal();
         $this->assertInstanceOf(ReactionTotal::class, $total);
         $this->assertSame(0, $total->count);
-        $this->assertSame(0, $total->weight);
+        $this->assertSame(0.0, $total->weight);
     }
 }

--- a/tests/Unit/Reacter/Facades/ReacterTest.php
+++ b/tests/Unit/Reacter/Facades/ReacterTest.php
@@ -238,7 +238,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_reactable(): void
+    public function it_can_check_has_reacted_to_reactable(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -257,7 +257,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_reactable_when_reactable_is_not_registered_as_reactant(): void
+    public function it_can_check_has_reacted_to_reactable_when_reactable_is_not_registered_as_reactant(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -269,7 +269,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_reactable_when_reactable_is_not_persisted(): void
+    public function it_can_check_has_reacted_to_reactable_when_reactable_is_not_persisted(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -281,7 +281,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_reactable(): void
+    public function it_can_check_has_not_reacted_to_reactable(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -303,7 +303,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_reactable_when_reactable_is_not_registered_as_reactant(): void
+    public function it_can_check_has_not_reacted_to_reactable_when_reactable_is_not_registered_as_reactant(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -315,7 +315,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_reactable_when_reactable_is_not_persisted(): void
+    public function it_can_check_has_not_reacted_to_reactable_when_reactable_is_not_persisted(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -327,7 +327,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_reactable_with_type(): void
+    public function it_can_check_has_reacted_to_reactable_with_type(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -346,7 +346,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_reactable_with_type_when_reactable_is_not_registered_as_reactant(): void
+    public function it_can_check_has_reacted_to_reactable_with_type_when_reactable_is_not_registered_as_reactant(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -359,7 +359,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_reactable_with_type_when_reactable_is_not_persisted(): void
+    public function it_can_check_has_reacted_to_reactable_with_type_when_reactable_is_not_persisted(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -372,7 +372,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_reaction_type_invalid_on_is_reacted_to_with_type_when_reaction_type_not_exist(): void
+    public function it_throws_reaction_type_invalid_on_has_reacted_to_with_type_when_reaction_type_not_exist(): void
     {
         $this->expectException(ReactionTypeInvalid::class);
 
@@ -384,7 +384,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_reactable_with_type(): void
+    public function it_can_check_has_not_reacted_to_reactable_with_type(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -408,7 +408,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_reactable_with_type_when_reactable_is_not_registered_as_reactant(): void
+    public function it_can_check_has_not_reacted_to_reactable_with_type_when_reactable_is_not_registered_as_reactant(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -421,7 +421,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_reactable_with_type_when_reactable_is_not_persisted(): void
+    public function it_can_check_has_not_reacted_to_reactable_with_type_when_reactable_is_not_persisted(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -434,7 +434,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_reaction_type_invalid_on_is_not_reacted_to_with_type_when_reaction_type_not_exist(): void
+    public function it_throws_reaction_type_invalid_on_has_not_reacted_to_with_type_when_reaction_type_not_exist(): void
     {
         $this->expectException(ReactionTypeInvalid::class);
 
@@ -443,5 +443,215 @@ final class ReacterTest extends TestCase
         $reactable = factory(Article::class)->create();
 
         $reacterFacade->hasNotReactedTo($reactable, 'NotExist');
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_reactable_with_rate(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = factory(Article::class)->create();
+        $reactant = $reactable->getLoveReactant();
+        factory(Reaction::class)->create([
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+
+        $isReacted = $reacterFacade->hasReactedTo($reactable, null, 2.0);
+
+        $this->assertTrue($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_reactable_with_rate_when_reactable_is_not_registered_as_reactant(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = factory(ArticleWithoutAutoReactantCreate::class)->create();
+
+        $isReacted = $reacterFacade->hasReactedTo($reactable, null, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_reactable_with_rate_when_reactable_is_not_persisted(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = new Article();
+
+        $isReacted = $reacterFacade->hasReactedTo($reactable, null, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_reactable_with_rate(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = factory(Article::class)->create();
+        $reactant = $reactable->getLoveReactant();
+        factory(Reaction::class)->create([
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.2,
+        ]);
+        factory(Reaction::class)->create([
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+
+        $isNotReacted = $reacterFacade->hasNotReactedTo($reactable, null, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_reactable_with_rate_when_reactable_is_not_registered_as_reactant(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = factory(ArticleWithoutAutoReactantCreate::class)->create();
+
+        $isNotReacted = $reacterFacade->hasNotReactedTo($reactable, null, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_reactable_with_rate_when_reactable_is_not_persisted(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = new Article();
+
+        $isNotReacted = $reacterFacade->hasNotReactedTo($reactable, null, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_reactable_with_type_and_rate(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = factory(Article::class)->create();
+        $reactant = $reactable->getLoveReactant();
+        $reactionType = factory(ReactionType::class)->create();
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+
+        $isReacted = $reacterFacade->hasReactedTo($reactable, $reactionType->getName(), 2.0);
+
+        $this->assertTrue($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_reactable_with_type_and_rate_when_reactable_is_not_registered_as_reactant(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = factory(ArticleWithoutAutoReactantCreate::class)->create();
+        $reactionType = factory(ReactionType::class)->create();
+
+        $isReacted = $reacterFacade->hasReactedTo($reactable, $reactionType->getName(), 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_reactable_with_type_and_rate_when_reactable_is_not_persisted(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = new Article();
+        $reactionType = factory(ReactionType::class)->create();
+
+        $isReacted = $reacterFacade->hasReactedTo($reactable, $reactionType->getName(), 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_throws_reaction_type_invalid_on_has_reacted_to_with_type_and_rate_when_reaction_type_not_exist(): void
+    {
+        $this->expectException(ReactionTypeInvalid::class);
+
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = factory(Article::class)->create();
+
+        $reacterFacade->hasReactedTo($reactable, 'NotExist', 2.0);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_reactable_with_type_and_rate(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = factory(Article::class)->create();
+        $reactant = $reactable->getLoveReactant();
+        $reactionType = factory(ReactionType::class)->create();
+        $otherReactionType = factory(ReactionType::class)->create();
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $otherReactionType->getId(),
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.2,
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+
+        $isNotReacted = $reacterFacade->hasNotReactedTo($reactable, $reactionType->getName(), 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_reactable_with_type_and_rate_when_reactable_is_not_registered_as_reactant(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = factory(ArticleWithoutAutoReactantCreate::class)->create();
+        $reactionType = factory(ReactionType::class)->create();
+
+        $isNotReacted = $reacterFacade->hasNotReactedTo($reactable, $reactionType->getName(), 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_reactable_with_type_and_rate_when_reactable_is_not_persisted(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = new Article();
+        $reactionType = factory(ReactionType::class)->create();
+
+        $isNotReacted = $reacterFacade->hasNotReactedTo($reactable, $reactionType->getName(), 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_throws_reaction_type_invalid_on_has_not_reacted_to_with_type_and_rate_when_reaction_type_not_exist(): void
+    {
+        $this->expectException(ReactionTypeInvalid::class);
+
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = factory(Article::class)->create();
+
+        $reacterFacade->hasNotReactedTo($reactable, 'NotExist', 2.0);
     }
 }

--- a/tests/Unit/Reacter/Facades/ReacterTest.php
+++ b/tests/Unit/Reacter/Facades/ReacterTest.php
@@ -44,7 +44,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_react_to_reactable(): void
+    public function it_can_react_to_reactable_without_rate(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reacterFacade = new ReacterFacade($reacter);
@@ -56,6 +56,7 @@ final class ReacterTest extends TestCase
         $this->assertCount(1, $reacter->reactions);
         $assertReaction = $reacter->reactions->first();
         $this->assertTrue($assertReaction->reactant->reactable->is($reactable));
+        $this->assertSame(1.0, $assertReaction->rate);
     }
 
     /** @test */
@@ -71,6 +72,37 @@ final class ReacterTest extends TestCase
         $this->assertCount(1, $reacter->reactions);
         $assertReaction = $reacter->reactions->first();
         $this->assertTrue($assertReaction->reactant->reactable->is($reactable));
+    }
+
+    /** @test */
+    public function it_can_react_to_reactable_with_rate(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = factory(User::class)->create();
+        $reactionType = factory(ReactionType::class)->create();
+
+        $reacterFacade->reactTo($reactable, $reactionType->getName(), 2.0);
+
+        $this->assertCount(1, $reacter->reactions);
+        $assertReaction = $reacter->reactions->first();
+        $this->assertSame(2.0, $assertReaction->rate);
+    }
+
+    /** @test */
+    public function it_can_change_reaction_rate_with_react_to_when_reaction_already_exists(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reacterFacade = new ReacterFacade($reacter);
+        $reactable = factory(User::class)->create();
+        $reactionType = factory(ReactionType::class)->create();
+
+        $reacterFacade->reactTo($reactable, $reactionType->getName());
+        $reacterFacade->reactTo($reactable, $reactionType->getName(), 2.0);
+
+        $this->assertCount(1, $reacter->reactions);
+        $assertReaction = $reacter->reactions->first();
+        $this->assertSame(2.0, $assertReaction->rate);
     }
 
     /** @test */

--- a/tests/Unit/Reacter/Models/NullReacterTest.php
+++ b/tests/Unit/Reacter/Models/NullReacterTest.php
@@ -191,7 +191,7 @@ final class NullReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to(): void
+    public function it_can_check_has_reacted_to(): void
     {
         $reacterable = new User();
         $reacter = new NullReacter($reacterable);
@@ -203,7 +203,7 @@ final class NullReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to(): void
+    public function it_can_check_has_not_reacted_to(): void
     {
         $reacterable = new User();
         $reacter = new NullReacter($reacterable);
@@ -215,7 +215,7 @@ final class NullReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_with_type(): void
+    public function it_can_check_has_reacted_to_with_type(): void
     {
         $reacterable = new User();
         $reacter = new NullReacter($reacterable);
@@ -228,7 +228,7 @@ final class NullReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_with_type(): void
+    public function it_can_check_has_not_reacted_to_with_type(): void
     {
         $reacterable = new User();
         $reacter = new NullReacter($reacterable);
@@ -236,6 +236,56 @@ final class NullReacterTest extends TestCase
         $reactionType = new ReactionType();
 
         $isReacted = $reacter->hasNotReactedTo($reactant, $reactionType);
+
+        $this->assertTrue($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_with_rate(): void
+    {
+        $reacterable = new User();
+        $reacter = new NullReacter($reacterable);
+        $reactant = factory(Reactant::class)->make();
+
+        $isReacted = $reacter->hasReactedTo($reactant, null, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_with_rate(): void
+    {
+        $reacterable = new User();
+        $reacter = new NullReacter($reacterable);
+        $reactant = factory(Reactant::class)->make();
+
+        $isReacted = $reacter->hasNotReactedTo($reactant, null, 2.0);
+
+        $this->assertTrue($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_with_type_and_rate(): void
+    {
+        $reacterable = new User();
+        $reacter = new NullReacter($reacterable);
+        $reactant = factory(Reactant::class)->make();
+        $reactionType = new ReactionType();
+
+        $isReacted = $reacter->hasReactedTo($reactant, $reactionType, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_with_type_and_rate(): void
+    {
+        $reacterable = new User();
+        $reacter = new NullReacter($reacterable);
+        $reactant = factory(Reactant::class)->make();
+        $reactionType = new ReactionType();
+
+        $isReacted = $reacter->hasNotReactedTo($reactant, $reactionType, 2.0);
 
         $this->assertTrue($isReacted);
     }

--- a/tests/Unit/Reacter/Models/ReacterTest.php
+++ b/tests/Unit/Reacter/Models/ReacterTest.php
@@ -48,6 +48,7 @@ final class ReacterTest extends TestCase
         ]);
 
         $this->assertSame('4', $reacter->getAttribute('id'));
+        $this->assertSame('4', $reacter->getId());
     }
 
     /** @test */

--- a/tests/Unit/Reacter/Models/ReacterTest.php
+++ b/tests/Unit/Reacter/Models/ReacterTest.php
@@ -312,7 +312,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_reactant(): void
+    public function it_can_check_has_reacted_to_reactant(): void
     {
         $reactionType = factory(ReactionType::class)->create();
         $reacter = factory(Reacter::class)->create();
@@ -329,7 +329,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_reactant_when_reactant_is_null_object(): void
+    public function it_can_check_has_reacted_to_reactant_when_reactant_is_null_object(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reactant = new NullReactant(new Article());
@@ -340,7 +340,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_reactant_when_reactant_is_not_persisted(): void
+    public function it_can_check_has_reacted_to_reactant_when_reactant_is_not_persisted(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reactant = Reactant::query()->make();
@@ -351,7 +351,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_reactant(): void
+    public function it_can_check_has_not_reacted_to_reactant(): void
     {
         $reactionType = factory(ReactionType::class)->create();
         $reacter = factory(Reacter::class)->create();
@@ -371,7 +371,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_reactant_when_reactant_is_null_object(): void
+    public function it_can_check_has_not_reacted_to_reactant_when_reactant_is_null_object(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reactant = new NullReactant(new Article());
@@ -382,7 +382,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_reactant_when_reactant_is_not_persisted(): void
+    public function it_can_check_has_not_reacted_to_reactant_when_reactant_is_not_persisted(): void
     {
         $reacter = factory(Reacter::class)->create();
         $reactant = Reactant::query()->make();
@@ -393,7 +393,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_reactant_with_type(): void
+    public function it_can_check_has_reacted_to_reactant_with_type(): void
     {
         $reactionType = factory(ReactionType::class)->create();
         $reacter = factory(Reacter::class)->create();
@@ -410,7 +410,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_reactant_with_type_when_reactant_is_null_object(): void
+    public function it_can_check_has_reacted_to_reactant_with_type_when_reactant_is_null_object(): void
     {
         $reactionType = factory(ReactionType::class)->create();
         $reacter = factory(Reacter::class)->create();
@@ -422,7 +422,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_reacted_to_reactant_with_type_when_reactant_is_not_persisted(): void
+    public function it_can_check_has_reacted_to_reactant_with_type_when_reactant_is_not_persisted(): void
     {
         $reactionType = factory(ReactionType::class)->create();
         $reacter = factory(Reacter::class)->create();
@@ -434,7 +434,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_reactant_with_type(): void
+    public function it_can_check_has_not_reacted_to_reactant_with_type(): void
     {
         $reactionType = factory(ReactionType::class)->create();
         $otherReactionType = factory(ReactionType::class)->create();
@@ -456,7 +456,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_reactant_with_type_when_reactant_is_null_object(): void
+    public function it_can_check_has_not_reacted_to_reactant_with_type_when_reactant_is_null_object(): void
     {
         $reactionType = factory(ReactionType::class)->create();
         $reacter = factory(Reacter::class)->create();
@@ -468,13 +468,183 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_is_not_reacted_to_reactant_with_type_when_reactant_is_not_persisted(): void
+    public function it_can_check_has_not_reacted_to_reactant_with_type_when_reactant_is_not_persisted(): void
     {
         $reactionType = factory(ReactionType::class)->create();
         $reacter = factory(Reacter::class)->create();
         $reactant = Reactant::query()->make();
 
         $isNotReacted = $reacter->hasNotReactedTo($reactant, $reactionType);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_reactant_with_rate(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reactant = factory(Reactant::class)->create();
+        factory(Reaction::class)->create([
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+
+        $isReacted = $reacter->hasReactedTo($reactant, null, 2.0);
+
+        $this->assertTrue($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_reactant_with_rate_when_reactant_is_null_object(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reactant = new NullReactant(new Article());
+
+        $isReacted = $reacter->hasReactedTo($reactant, null, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_reactant_with_rate_when_reactant_is_not_persisted(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reactant = Reactant::query()->make();
+
+        $isReacted = $reacter->hasReactedTo($reactant, null, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_reactant_with_rate(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reactant = factory(Reactant::class)->create();
+        factory(Reaction::class)->create([
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.2,
+        ]);
+        factory(Reaction::class)->create([
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+
+        $isNotReacted = $reacter->hasNotReactedTo($reactant, null, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_reactant_with_rate_when_reactant_is_null_object(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reactant = new NullReactant(new Article());
+
+        $isNotReacted = $reacter->hasNotReactedTo($reactant, null, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_reactant_with_rate_when_reactant_is_not_persisted(): void
+    {
+        $reacter = factory(Reacter::class)->create();
+        $reactant = Reactant::query()->make();
+
+        $isNotReacted = $reacter->hasNotReactedTo($reactant, null, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_reactant_with_type_and_rate(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactant = factory(Reactant::class)->create();
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+
+        $isReacted = $reacter->hasReactedTo($reactant, $reactionType, 2.0);
+
+        $this->assertTrue($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_reactant_with_type_and_rate_when_reactant_is_null_object(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactant = new NullReactant(new Article());
+
+        $isReacted = $reacter->hasReactedTo($reactant, $reactionType, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_reacted_to_reactant_with_type_and_rate_when_reactant_is_not_persisted(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactant = Reactant::query()->make();
+
+        $isReacted = $reacter->hasReactedTo($reactant, $reactionType, 2.0);
+
+        $this->assertFalse($isReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_reactant_with_type_and_rate(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $otherReactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactant = factory(Reactant::class)->create();
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $otherReactionType->getId(),
+            'reacter_id' => $reacter->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.2,
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactant->getId(),
+            'rate' => 2.0,
+        ]);
+
+        $isNotReacted = $reacter->hasNotReactedTo($reactant, $reactionType, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_reactant_with_type_and_rate_when_reactant_is_null_object(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactant = new NullReactant(new Article());
+
+        $isNotReacted = $reacter->hasNotReactedTo($reactant, $reactionType, 2.0);
+
+        $this->assertTrue($isNotReacted);
+    }
+
+    /** @test */
+    public function it_can_check_has_not_reacted_to_reactant_with_type_and_rate_when_reactant_is_not_persisted(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactant = Reactant::query()->make();
+
+        $isNotReacted = $reacter->hasNotReactedTo($reactant, $reactionType, 2.0);
 
         $this->assertTrue($isNotReacted);
     }

--- a/tests/Unit/Reacter/Models/ReacterTest.php
+++ b/tests/Unit/Reacter/Models/ReacterTest.php
@@ -182,6 +182,21 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
+    public function it_can_change_reaction_rate_with_react_to_when_reaction_already_exists(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactant = factory(Reactant::class)->create();
+
+        $reacter->reactTo($reactant, $reactionType);
+        $reacter->reactTo($reactant, $reactionType, 2);
+
+        $this->assertCount(1, $reacter->reactions);
+        $assertReaction = $reacter->reactions->first();
+        $this->assertSame(2.0, $assertReaction->rate);
+    }
+
+    /** @test */
     public function it_throws_reactant_invalid_on_react_to_when_reactant_is_null_object(): void
     {
         $this->expectException(ReactantInvalid::class);
@@ -206,7 +221,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_cannot_duplicate_reactions(): void
+    public function it_throws_reaction_already_exists_when_react_to_creating_duplicate(): void
     {
         $this->expectException(ReactionAlreadyExists::class);
 

--- a/tests/Unit/Reacter/Models/ReacterTest.php
+++ b/tests/Unit/Reacter/Models/ReacterTest.php
@@ -153,7 +153,7 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
-    public function it_can_react_to_reactant(): void
+    public function it_can_react_to_reactant_without_rate(): void
     {
         $reactionType = factory(ReactionType::class)->create();
         $reacter = factory(Reacter::class)->create();
@@ -165,6 +165,7 @@ final class ReacterTest extends TestCase
         $this->assertCount(1, $reacter->reactions);
         $assertReaction = $reacter->reactions->first();
         $this->assertTrue($assertReaction->reactant->is($reactant));
+        $this->assertSame(1.0, $assertReaction->rate);
     }
 
     /** @test */
@@ -183,6 +184,20 @@ final class ReacterTest extends TestCase
     }
 
     /** @test */
+    public function it_can_react_to_reactable_with_rate(): void
+    {
+        $reactionType = factory(ReactionType::class)->create();
+        $reacter = factory(Reacter::class)->create();
+        $reactant = factory(Reactant::class)->create();
+
+        $reacter->reactTo($reactant, $reactionType, 2.0);
+
+        $this->assertCount(1, $reacter->reactions);
+        $assertReaction = $reacter->reactions->first();
+        $this->assertSame(2.0, $assertReaction->rate);
+    }
+
+    /** @test */
     public function it_can_change_reaction_rate_with_react_to_when_reaction_already_exists(): void
     {
         $reactionType = factory(ReactionType::class)->create();
@@ -190,7 +205,7 @@ final class ReacterTest extends TestCase
         $reactant = factory(Reactant::class)->create();
 
         $reacter->reactTo($reactant, $reactionType);
-        $reacter->reactTo($reactant, $reactionType, 2);
+        $reacter->reactTo($reactant, $reactionType, 2.0);
 
         $this->assertCount(1, $reacter->reactions);
         $assertReaction = $reacter->reactions->first();

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -64,7 +64,7 @@ final class ReactionTest extends TestCase
         $this->expectException(RateValueInvalid::class);
 
         new Reaction([
-            'rate' => Reaction::MIN_RATE - 0.01,
+            'rate' => Reaction::RATE_MIN - 0.01,
         ]);
     }
 
@@ -74,7 +74,7 @@ final class ReactionTest extends TestCase
         $this->expectException(RateValueInvalid::class);
 
         new Reaction([
-            'rate' => Reaction::MAX_RATE + 0.01,
+            'rate' => Reaction::RATE_MAX + 0.01,
         ]);
     }
 
@@ -83,8 +83,8 @@ final class ReactionTest extends TestCase
     {
         $reaction = new Reaction();
 
-        $this->assertSame(Reaction::DEFAULT_RATE, $reaction->getAttribute('rate'));
-        $this->assertSame(Reaction::DEFAULT_RATE, $reaction->getRate());
+        $this->assertSame(Reaction::RATE_DEFAULT, $reaction->getAttribute('rate'));
+        $this->assertSame(Reaction::RATE_DEFAULT, $reaction->getRate());
     }
 
     /** @test */

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -63,6 +63,7 @@ final class ReactionTest extends TestCase
         $reaction = new Reaction();
 
         $this->assertSame(Reaction::DEFAULT_RATE, $reaction->getAttribute('rate'));
+        $this->assertSame(Reaction::DEFAULT_RATE, $reaction->getRate());
     }
 
     /** @test */
@@ -230,14 +231,6 @@ final class ReactionTest extends TestCase
         $assertRate = $reaction->getRate();
 
         $this->assertSame(2.0, $assertRate);
-    }
-
-    /** @test */
-    public function it_returns_default_rate_on_get_rate_when_rate_not_set(): void
-    {
-        $reaction = new Reaction();
-
-        $this->assertSame(Reaction::DEFAULT_RATE, $reaction->getRate());
     }
 
     /** @test */

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -58,6 +58,26 @@ final class ReactionTest extends TestCase
     }
 
     /** @test */
+    public function it_throws_exception_on_fill_rate_with_lower_than_minimum_value(): void
+    {
+        $this->expectException(\OutOfRangeException::class);
+
+        new Reaction([
+            'rate' => 0,
+        ]);
+    }
+
+    /** @test */
+    public function it_throws_exception_on_fill_rate_with_bigger_than_maximum_value(): void
+    {
+        $this->expectException(\OutOfRangeException::class);
+
+        new Reaction([
+            'rate' => 100,
+        ]);
+    }
+
+    /** @test */
     public function it_has_default_rate_value(): void
     {
         $reaction = new Reaction();

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -73,6 +73,7 @@ final class ReactionTest extends TestCase
         ]);
 
         $this->assertSame('4', $reaction->getAttribute('id'));
+        $this->assertSame('4', $reaction->getId());
     }
 
     /** @test */
@@ -83,6 +84,7 @@ final class ReactionTest extends TestCase
         ]);
 
         $this->assertSame(4.0, $reaction->getAttribute('rate'));
+        $this->assertSame(4.0, $reaction->getRate());
     }
 
     /** @test */

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Unit\Reaction\Models;
 
+use Cog\Contracts\Love\Reaction\Exceptions\RateValueInvalid;
 use Cog\Laravel\Love\Reactant\Models\NullReactant;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\Reacter\Models\NullReacter;
@@ -60,20 +61,20 @@ final class ReactionTest extends TestCase
     /** @test */
     public function it_throws_exception_on_fill_rate_with_lower_than_minimum_value(): void
     {
-        $this->expectException(\OutOfRangeException::class);
+        $this->expectException(RateValueInvalid::class);
 
         new Reaction([
-            'rate' => 0,
+            'rate' => Reaction::MIN_RATE - 0.01,
         ]);
     }
 
     /** @test */
     public function it_throws_exception_on_fill_rate_with_bigger_than_maximum_value(): void
     {
-        $this->expectException(\OutOfRangeException::class);
+        $this->expectException(RateValueInvalid::class);
 
         new Reaction([
-            'rate' => 100,
+            'rate' => Reaction::MAX_RATE + 0.01,
         ]);
     }
 

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -28,16 +28,6 @@ use TypeError;
 final class ReactionTest extends TestCase
 {
     /** @test */
-    public function it_can_fill_reaction_type_id(): void
-    {
-        $reaction = new Reaction([
-            'reaction_type_id' => 4,
-        ]);
-
-        $this->assertSame(4, $reaction->getAttribute('reaction_type_id'));
-    }
-
-    /** @test */
     public function it_can_fill_reactant_id(): void
     {
         $reaction = new Reaction([
@@ -45,6 +35,16 @@ final class ReactionTest extends TestCase
         ]);
 
         $this->assertSame(4, $reaction->getAttribute('reactant_id'));
+    }
+
+    /** @test */
+    public function it_can_fill_reaction_type_id(): void
+    {
+        $reaction = new Reaction([
+            'reaction_type_id' => 4,
+        ]);
+
+        $this->assertSame(4, $reaction->getAttribute('reaction_type_id'));
     }
 
     /** @test */
@@ -144,30 +144,6 @@ final class ReactionTest extends TestCase
     }
 
     /** @test */
-    public function it_can_get_type(): void
-    {
-        $type = factory(ReactionType::class)->create();
-
-        /** @var \Cog\Laravel\Love\Reaction\Models\Reaction $reaction */
-        $reaction = factory(Reaction::class)->create([
-            'reaction_type_id' => $type->getId(),
-        ]);
-
-        $assertType = $reaction->getType();
-        $this->assertTrue($assertType->is($type));
-    }
-
-    /** @test */
-    public function it_throws_exception_on_get_type_when_type_is_null(): void
-    {
-        $this->expectException(TypeError::class);
-
-        $reaction = new Reaction();
-
-        $reaction->getType();
-    }
-
-    /** @test */
     public function it_can_get_reactant(): void
     {
         $reactionType = factory(ReactionType::class)->create();
@@ -215,6 +191,51 @@ final class ReactionTest extends TestCase
         $reaction = new Reaction();
 
         $reaction->getReacter();
+    }
+
+    /** @test */
+    public function it_can_get_type(): void
+    {
+        $type = factory(ReactionType::class)->create();
+
+        /** @var \Cog\Laravel\Love\Reaction\Models\Reaction $reaction */
+        $reaction = factory(Reaction::class)->create([
+            'reaction_type_id' => $type->getId(),
+        ]);
+
+        $assertType = $reaction->getType();
+        $this->assertTrue($assertType->is($type));
+    }
+
+    /** @test */
+    public function it_throws_exception_on_get_type_when_type_is_null(): void
+    {
+        $this->expectException(TypeError::class);
+
+        $reaction = new Reaction();
+
+        $reaction->getType();
+    }
+
+    /** @test */
+    public function it_can_get_rate(): void
+    {
+        /** @var \Cog\Laravel\Love\Reaction\Models\Reaction $reaction */
+        $reaction = factory(Reaction::class)->create([
+            'rate' => 2.0,
+        ]);
+
+        $assertRate = $reaction->getRate();
+
+        $this->assertSame(2.0, $assertRate);
+    }
+
+    /** @test */
+    public function it_returns_default_rate_on_get_rate_when_rate_not_set(): void
+    {
+        $reaction = new Reaction();
+
+        $this->assertSame(Reaction::DEFAULT_RATE, $reaction->getRate());
     }
 
     /** @test */

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Unit\Reaction\Models;
 
-use Cog\Contracts\Love\Reaction\Exceptions\RateValueInvalid;
+use Cog\Contracts\Love\Reaction\Exceptions\RateOutOfRange;
 use Cog\Laravel\Love\Reactant\Models\NullReactant;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\Reacter\Models\NullReacter;
@@ -59,9 +59,9 @@ final class ReactionTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_exception_on_fill_rate_with_lower_than_minimum_value(): void
+    public function it_throws_rate_out_of_range_on_fill_rate_with_underflow_value(): void
     {
-        $this->expectException(RateValueInvalid::class);
+        $this->expectException(RateOutOfRange::class);
 
         new Reaction([
             'rate' => Reaction::RATE_MIN - 0.01,
@@ -69,9 +69,9 @@ final class ReactionTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_exception_on_fill_rate_with_bigger_than_maximum_value(): void
+    public function it_throws_rate_out_of_range_on_fill_rate_with_overflow_value(): void
     {
-        $this->expectException(RateValueInvalid::class);
+        $this->expectException(RateOutOfRange::class);
 
         new Reaction([
             'rate' => Reaction::RATE_MAX + 0.01,

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -233,6 +233,22 @@ final class ReactionTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_weight_affected_by_rate(): void
+    {
+        $reactionType = factory(ReactionType::class)->create([
+            'mass' => 4,
+        ]);
+
+        /** @var \Cog\Laravel\Love\Reaction\Models\Reaction $reaction */
+        $reaction = factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'rate' => 1.02,
+        ]);
+
+        $this->assertSame(4.08, $reaction->getWeight());
+    }
+
+    /** @test */
     public function it_can_check_if_reaction_is_of_type(): void
     {
         $reactionType1 = factory(ReactionType::class)->create();

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -48,6 +48,24 @@ final class ReactionTest extends TestCase
     }
 
     /** @test */
+    public function it_can_fill_rate(): void
+    {
+        $reaction = new Reaction([
+            'rate' => 4.0,
+        ]);
+
+        $this->assertSame(4.0, $reaction->getAttribute('rate'));
+    }
+
+    /** @test */
+    public function it_has_default_rate_value(): void
+    {
+        $reaction = new Reaction();
+
+        $this->assertSame(Reaction::DEFAULT_RATE, $reaction->getAttribute('rate'));
+    }
+
+    /** @test */
     public function it_casts_id_to_string(): void
     {
         $reaction = factory(Reaction::class)->make([
@@ -55,6 +73,16 @@ final class ReactionTest extends TestCase
         ]);
 
         $this->assertSame('4', $reaction->getAttribute('id'));
+    }
+
+    /** @test */
+    public function it_casts_rate_to_float(): void
+    {
+        $reaction = new Reaction([
+            'rate' => '4',
+        ]);
+
+        $this->assertSame(4.0, $reaction->getAttribute('rate'));
     }
 
     /** @test */

--- a/tests/Unit/Reaction/Models/ReactionTest.php
+++ b/tests/Unit/Reaction/Models/ReactionTest.php
@@ -229,7 +229,7 @@ final class ReactionTest extends TestCase
             'reaction_type_id' => $reactionType->getId(),
         ]);
 
-        $this->assertSame(4, $reaction->getWeight());
+        $this->assertSame(4.0, $reaction->getWeight());
     }
 
     /** @test */

--- a/tests/Unit/Reaction/Observers/ReactionObserverTest.php
+++ b/tests/Unit/Reaction/Observers/ReactionObserverTest.php
@@ -49,7 +49,7 @@ final class ReactionObserverTest extends TestCase
         $this->assertCount(0, $initialCounters);
         $this->assertCount(1, $assertCounters);
         $this->assertSame(1, $assertCounters->get(0)->count);
-        $this->assertSame(4, $assertCounters->get(0)->weight);
+        $this->assertSame(4.0, $assertCounters->get(0)->weight);
     }
 
     /** @test */
@@ -106,7 +106,7 @@ final class ReactionObserverTest extends TestCase
         $assertCounters = $reactant->fresh()->reactionCounters;
         $this->assertCount(1, $assertCounters);
         $this->assertSame(0, $assertCounters->get(0)->count);
-        $this->assertSame(0, $assertCounters->get(0)->weight);
+        $this->assertSame(0.0, $assertCounters->get(0)->weight);
     }
 
     /** @test */
@@ -145,7 +145,7 @@ final class ReactionObserverTest extends TestCase
             'reaction_type_id' => $reactionType->getId(),
         ]);
 
-        $this->assertSame(8, $counter->fresh()->weight);
+        $this->assertSame(8.0, $counter->fresh()->weight);
     }
 
     /** @test */
@@ -166,7 +166,7 @@ final class ReactionObserverTest extends TestCase
 
         $reactions->get(0)->delete();
 
-        $this->assertSame(8, $counter->fresh()->weight);
+        $this->assertSame(8.0, $counter->fresh()->weight);
     }
 
     /** @test */
@@ -186,7 +186,7 @@ final class ReactionObserverTest extends TestCase
             'reaction_type_id' => $reactionType->getId(),
         ]);
 
-        $this->assertSame(-8, $counter->fresh()->weight);
+        $this->assertSame(-8.0, $counter->fresh()->weight);
     }
 
     /** @test */
@@ -207,7 +207,7 @@ final class ReactionObserverTest extends TestCase
 
         $reactions->get(0)->delete();
 
-        $this->assertSame(-8, $counter->fresh()->weight);
+        $this->assertSame(-8.0, $counter->fresh()->weight);
     }
 
     /** @test */
@@ -255,7 +255,7 @@ final class ReactionObserverTest extends TestCase
         ]);
 
         $total = $reactant->reactionTotal;
-        $this->assertSame(8, $total->weight);
+        $this->assertSame(8.0, $total->weight);
     }
 
     /** @test */
@@ -273,7 +273,7 @@ final class ReactionObserverTest extends TestCase
         $reactions->get(0)->delete();
 
         $total = $reactant->reactionTotal;
-        $this->assertSame(8, $total->weight);
+        $this->assertSame(8.0, $total->weight);
     }
 
     /** @test */
@@ -290,7 +290,7 @@ final class ReactionObserverTest extends TestCase
         ]);
 
         $total = $reactant->reactionTotal;
-        $this->assertSame(-8, $total->weight);
+        $this->assertSame(-8.0, $total->weight);
     }
 
     /** @test */
@@ -308,6 +308,6 @@ final class ReactionObserverTest extends TestCase
         $reactions->get(0)->delete();
 
         $total = $reactant->reactionTotal;
-        $this->assertSame(-8, $total->weight);
+        $this->assertSame(-8.0, $total->weight);
     }
 }

--- a/tests/Unit/Reaction/Observers/ReactionObserverTest.php
+++ b/tests/Unit/Reaction/Observers/ReactionObserverTest.php
@@ -28,7 +28,7 @@ final class ReactionObserverTest extends TestCase
             'rate' => null,
         ]);
 
-        $this->assertSame(Reaction::DEFAULT_RATE, $counter->getAttribute('rate'));
+        $this->assertSame(Reaction::RATE_DEFAULT, $counter->getAttribute('rate'));
     }
 
     /** @test */

--- a/tests/Unit/Reaction/Observers/ReactionObserverTest.php
+++ b/tests/Unit/Reaction/Observers/ReactionObserverTest.php
@@ -22,6 +22,16 @@ use Cog\Tests\Laravel\Love\TestCase;
 final class ReactionObserverTest extends TestCase
 {
     /** @test */
+    public function it_sets_default_rate_value_when_rate_value_is_null(): void
+    {
+        $counter = factory(Reaction::class)->create([
+            'rate' => null,
+        ]);
+
+        $this->assertSame(Reaction::DEFAULT_RATE, $counter->getAttribute('rate'));
+    }
+
+    /** @test */
     public function it_creates_counter_on_reaction_created_when_counter_not_exists(): void
     {
         $reactionType = factory(ReactionType::class)->create([

--- a/tests/Unit/ReactionType/Models/ReactionTypeTest.php
+++ b/tests/Unit/ReactionType/Models/ReactionTypeTest.php
@@ -47,8 +47,8 @@ final class ReactionTypeTest extends TestCase
     {
         $type = new ReactionType();
 
-        $this->assertSame(ReactionType::DEFAULT_MASS, $type->getAttribute('mass'));
-        $this->assertSame(ReactionType::DEFAULT_MASS, $type->getMass());
+        $this->assertSame(ReactionType::MASS_DEFAULT, $type->getAttribute('mass'));
+        $this->assertSame(ReactionType::MASS_DEFAULT, $type->getMass());
     }
 
     /** @test */

--- a/tests/Unit/ReactionType/Models/ReactionTypeTest.php
+++ b/tests/Unit/ReactionType/Models/ReactionTypeTest.php
@@ -50,6 +50,7 @@ final class ReactionTypeTest extends TestCase
         ]);
 
         $this->assertSame('4', $type->getAttribute('id'));
+        $this->assertSame('4', $type->getId());
     }
 
     /** @test */
@@ -60,6 +61,7 @@ final class ReactionTypeTest extends TestCase
         ]);
 
         $this->assertSame(4, $type->getAttribute('mass'));
+        $this->assertSame(4, $type->getMass());
     }
 
     /** @test */

--- a/tests/Unit/ReactionType/Models/ReactionTypeTest.php
+++ b/tests/Unit/ReactionType/Models/ReactionTypeTest.php
@@ -43,6 +43,15 @@ final class ReactionTypeTest extends TestCase
     }
 
     /** @test */
+    public function it_has_default_rate_value(): void
+    {
+        $type = new ReactionType();
+
+        $this->assertSame(ReactionType::DEFAULT_MASS, $type->getAttribute('mass'));
+        $this->assertSame(ReactionType::DEFAULT_MASS, $type->getMass());
+    }
+
+    /** @test */
     public function it_casts_id_to_string(): void
     {
         $type = factory(ReactionType::class)->make([


### PR DESCRIPTION
Part of #85 

### To Do

- [x] Add `rate` attribute to `Reaction` model
- [x] Add `getRate` method to `Reaction` model
- [x] Change `weight` attributes type to `float`
- [x] Change `getWeight` methods return type to `float`
- [x] Change `incrementWeight` methods argument type to `float`
- [x] Change `decrementWeight` methods argument type to `float`
- [x] Change `love_reactant_reaction_counters.weight` db column type to `decimal(13, 2)`
- [x] Change `love_reactant_reaction_totals.weight` db column type to `decimal(13, 2)`
- [x] Change `love_reactions.weight` db column type to `decimal(4, 2)`
- [x] Add `$rate` argument to `reactTo` method
- [x] Allow to change reaction `rate`
- [x] Add `$rate` to `Reactant::isReactedBy` method
- [x] Add `$rate` to `Reactant::isNotReactedBy` method
- [x] Add `$rate` to `Reacter::hasReactedTo` method
- [x] Add `$rate` to `Reacter::hasNotReactedTo` method
- [x] Test for  `love_reactions.rate` db column min value
- [x] Test for  `love_reactions.rate` db column max value
- [x] Write about min\max values in documentation

### Min\Max Values

- `Reaction::RATE_MIN = 0.01`
- `Reaction::RATE_MAX = 99.99`
- `ReactionCounter::WEIGHT_MIN = -99999999999.99`
- `ReactionCounter::WEIGHT_MAX = 99999999999.99`
- `ReactionTotal::WEIGHT_MIN = -99999999999.99`
- `ReactionTotal::WEIGHT_MAX = 99999999999.99`

I decided not to create constants for `ReactionCounter` & `ReactionTotal` weight ranges for now. They are computed automatically and it's nearly to impossible to reach the limits in near future.

How did I calculated this decimal value?

If we will take the most popular YouTube video with 40 000 000+ likes multiply this value by 99.99 (RATE_MAX) we will receive ~4 000 000 000 total weight (10 digits). Because decimals are stored using a binary format that packs nine decimal digits into 4 bytes, then we will have 2 packs for integer part (9 + 1) which will require 4 bytes + 1 byte. But +1 digit wouldn't add extra byte because 1-2 digits have same size of 1 byte, so we could start with 11 digits on the integer part and 2 digits on fractional part.

- `DECIMAL(4, 2)` require `2 + 1 = 3 bytes`
- `DECIMAL (13, 2)` require `4 + 1 + 1 = 6 bytes`

A `decimal` type can store a Maximum of 65 Digits values, with 30 digits after decimal point. This is another one reason why I decided not to add range limits for counters. You are free to modify your database columns and extend or reduce weight range without touching codebase.
