### PR TITLE
Change Artisan commands signature definition format

### DIFF
--- a/src/Console/Commands/ReactionTypeAdd.php
+++ b/src/Console/Commands/ReactionTypeAdd.php
@@ -16,18 +16,16 @@ namespace Cog\Laravel\Love\Console\Commands;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
 
 final class ReactionTypeAdd extends Command
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'love:reaction-type-add
-                            {--default : Create default Like & Dislike reactions}
-                            {--name= : The name of the reaction}
-                            {--mass= : The mass of the reaction}';
+    protected $name = 'love:reaction-type-add';
 
     /**
      * The console command description.
@@ -73,6 +71,15 @@ final class ReactionTypeAdd extends Command
         $this->createReactionType($name, $this->resolveMass());
 
         return 0;
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            ['default', null, InputOption::VALUE_NONE, 'Create default Like & Dislike reactions'],
+            ['name', null, InputOption::VALUE_OPTIONAL, 'The name of the reaction'],
+            ['mass', null, InputOption::VALUE_OPTIONAL, 'The mass of the reaction'],
+        ];
     }
 
     private function createDefaultReactionTypes(): void
@@ -150,4 +157,6 @@ final class ReactionTypeAdd extends Command
     {
         return preg_match('#^[A-Z][a-zA-Z0-9_]*$#', $name) === 0;
     }
+
+
 }

--- a/src/Console/Commands/ReactionTypeAdd.php
+++ b/src/Console/Commands/ReactionTypeAdd.php
@@ -157,6 +157,4 @@ final class ReactionTypeAdd extends Command
     {
         return preg_match('#^[A-Z][a-zA-Z0-9_]*$#', $name) === 0;
     }
-
-
 }

--- a/src/Console/Commands/Recount.php
+++ b/src/Console/Commands/Recount.php
@@ -23,17 +23,16 @@ use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Symfony\Component\Console\Input\InputOption;
 
 final class Recount extends Command
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'love:recount
-        {--model= : The name of the reactable model}
-        {--type= : The name of the reaction type}';
+    protected $name = 'love:recount';
 
     /**
      * The console command description.
@@ -95,6 +94,14 @@ final class Recount extends Command
             $this->getOutput()->progressAdvance();
         }
         $this->getOutput()->progressFinish();
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            ['model', null, InputOption::VALUE_OPTIONAL, 'The name of the reactable model'],
+            ['type', null, InputOption::VALUE_OPTIONAL, 'The name of the reaction type'],
+        ];
     }
 
     /**

--- a/src/Console/Commands/SetupReactable.php
+++ b/src/Console/Commands/SetupReactable.php
@@ -24,17 +24,16 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
 
 final class SetupReactable extends Command
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'love:setup-reactable
-        {--model= : The name of the reactable model}
-        {--nullable : Indicate if foreign column allows null values}';
+    protected $name = 'love:setup-reactable';
 
     /**
      * The console command description.
@@ -132,6 +131,14 @@ final class SetupReactable extends Command
         $this->composer->dumpAutoloads();
 
         return 0;
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            ['model', null, InputOption::VALUE_OPTIONAL, 'The name of the reactable model'],
+            ['nullable', null, InputOption::VALUE_NONE, 'Indicate if foreign column allows null values'],
+        ];
     }
 
     private function resolveModel(): string

--- a/src/Console/Commands/SetupReacterable.php
+++ b/src/Console/Commands/SetupReacterable.php
@@ -24,17 +24,16 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
 
 final class SetupReacterable extends Command
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'love:setup-reacterable
-        {--model= : The name of the reacterable model}
-        {--nullable : Indicate if foreign column allows null values}';
+    protected $name = 'love:setup-reacterable';
 
     /**
      * The console command description.
@@ -132,6 +131,14 @@ final class SetupReacterable extends Command
         $this->composer->dumpAutoloads();
 
         return 0;
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            ['model', null, InputOption::VALUE_OPTIONAL, 'The name of the reacterable model'],
+            ['nullable', null, InputOption::VALUE_NONE, 'Indicate if foreign column allows null values'],
+        ];
     }
 
     private function resolveModel(): string

--- a/src/Console/Commands/UpgradeV5ToV6.php
+++ b/src/Console/Commands/UpgradeV5ToV6.php
@@ -26,11 +26,11 @@ use Illuminate\Support\Str;
 final class UpgradeV5ToV6 extends Command
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'love:upgrade-v5-to-v6';
+    protected $name = 'love:upgrade-v5-to-v6';
 
     /**
      * The console command description.

--- a/src/Console/Commands/UpgradeV7ToV8.php
+++ b/src/Console/Commands/UpgradeV7ToV8.php
@@ -25,11 +25,11 @@ use Illuminate\Support\Facades\Schema;
 final class UpgradeV7ToV8 extends Command
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'love:upgrade-v7-to-v8';
+    protected $name = 'love:upgrade-v7-to-v8';
 
     /**
      * The console command description.


### PR DESCRIPTION
Instead of multi-line `$signature` string define command signature as `$name` string and `getOptions()` method which returns array of the available options.

This changes are fully backward compatible because all commands classes are `final`.