### PR TITLE
Fix contract dependency from concrete implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- ([#110]) Removed dependency of `RateOutOfRange` exception in contracts namespace on concrete `Reaction` model implementation
+- ([#110]) Renamed `withValue` method to `withValueBetween` in `RateOutOfRange` exception
+- ([#110]) Added `$minimumRate` parameter to `withValueBetween` method in `RateOutOfRange` exception
+- ([#110]) Added `$maximumRate` parameter to `withValueBetween` method in `RateOutOfRange` exception
+
 ## [8.0.0] - 2019-08-08
 
 Code has a lot of breaking changes because of new Weighted Reaction System.
@@ -400,6 +407,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#110]: https://github.com/cybercog/laravel-love/pull/110
 [#102]: https://github.com/cybercog/laravel-love/pull/102
 [#100]: https://github.com/cybercog/laravel-love/pull/100
 [#99]: https://github.com/cybercog/laravel-love/pull/99

--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,7 @@
     "require": {
         "php": "^7.1.3",
         "illuminate/database": "5.7.*|5.8.*",
-        "illuminate/support": "5.7.*|5.8.*",
-        "php-i/love": "dev-master"
+        "illuminate/support": "5.7.*|5.8.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
     "require": {
         "php": "^7.1.3",
         "illuminate/database": "5.7.*|5.8.*",
-        "illuminate/support": "5.7.*|5.8.*"
+        "illuminate/support": "5.7.*|5.8.*",
+        "php-i/love": "dev-master"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",

--- a/contracts/Reactable/Exceptions/ReactableInvalid.php
+++ b/contracts/Reactable/Exceptions/ReactableInvalid.php
@@ -22,11 +22,17 @@ final class ReactableInvalid extends RuntimeException implements
 {
     public static function classNotExists(string $type): self
     {
-        return new static("[{$type}] class or morph map not found.");
+        return new self(sprintf(
+            '[%s] class or morph map not found.',
+            $type
+        ));
     }
 
     public static function notImplementInterface(string $type): self
     {
-        return new static(sprintf('[%s] must implement `%s` contract.', $type, ReactableContract::class));
+        return new self(sprintf(
+            '[%s] must implement `%s` contract.',
+            $type, ReactableContract::class
+        ));
     }
 }

--- a/contracts/Reactant/Exceptions/ReactantInvalid.php
+++ b/contracts/Reactant/Exceptions/ReactantInvalid.php
@@ -21,6 +21,6 @@ final class ReactantInvalid extends RuntimeException implements
 {
     public static function notExists(): self
     {
-        return new static('Reactant not exists.');
+        return new self('Reactant not exists.');
     }
 }

--- a/contracts/Reactant/ReactionCounter/Exceptions/ReactionCounterDuplicate.php
+++ b/contracts/Reactant/ReactionCounter/Exceptions/ReactionCounterDuplicate.php
@@ -25,10 +25,9 @@ final class ReactionCounterDuplicate extends RuntimeException implements
         ReactionType $reactionType,
         Reactant $reactant
     ): self {
-        return new static(sprintf(
+        return new self(sprintf(
             'ReactionCounter for Reactant `%s` with ReactionType `%s` already exists.',
-            $reactant->getId(),
-            $reactionType->getId()
+            $reactant->getId(), $reactionType->getId()
         ));
     }
 }

--- a/contracts/Reactant/ReactionCounter/Exceptions/ReactionCounterInvalid.php
+++ b/contracts/Reactant/ReactionCounter/Exceptions/ReactionCounterInvalid.php
@@ -21,6 +21,6 @@ final class ReactionCounterInvalid extends RuntimeException implements
 {
     public static function notExists(): self
     {
-        return new static('ReactionCounter not exists.');
+        return new self('ReactionCounter not exists.');
     }
 }

--- a/contracts/Reactant/ReactionTotal/Exceptions/ReactionTotalDuplicate.php
+++ b/contracts/Reactant/ReactionTotal/Exceptions/ReactionTotalDuplicate.php
@@ -23,7 +23,7 @@ final class ReactionTotalDuplicate extends RuntimeException implements
     public static function forReactant(
         Reactant $reactant
     ): self {
-        return new static(sprintf(
+        return new self(sprintf(
             'ReactionTotal for Reactant `%s` already exists.',
             $reactant->getId()
         ));

--- a/contracts/Reactant/ReactionTotal/Exceptions/ReactionTotalInvalid.php
+++ b/contracts/Reactant/ReactionTotal/Exceptions/ReactionTotalInvalid.php
@@ -21,6 +21,6 @@ final class ReactionTotalInvalid extends RuntimeException implements
 {
     public static function notExists(): self
     {
-        return new static('ReactionTotal not exists.');
+        return new self('ReactionTotal not exists.');
     }
 }

--- a/contracts/Reacter/Exceptions/ReacterInvalid.php
+++ b/contracts/Reacter/Exceptions/ReacterInvalid.php
@@ -21,6 +21,6 @@ final class ReacterInvalid extends RuntimeException implements
 {
     public static function notExists(): self
     {
-        return new static('Reacter not exists.');
+        return new self('Reacter not exists.');
     }
 }

--- a/contracts/Reaction/Exceptions/RateOutOfRange.php
+++ b/contracts/Reaction/Exceptions/RateOutOfRange.php
@@ -14,19 +14,16 @@ declare(strict_types=1);
 namespace Cog\Contracts\Love\Reaction\Exceptions;
 
 use Cog\Contracts\Love\Exceptions\LoveThrowable;
-use Cog\Laravel\Love\Reaction\Models\Reaction;
 use OutOfRangeException;
 
 final class RateOutOfRange extends OutOfRangeException implements
     LoveThrowable
 {
-    public static function withValue(float $rate): self
+    public static function withValueBetween(float $rate, float $minimumRate, float $maximumRate): self
     {
         return new self(sprintf(
             'Invalid Reaction rate: `%s`. Must be between `%s` and `%s`',
-            $rate,
-            Reaction::RATE_MIN,
-            Reaction::RATE_MAX
+            $rate, $minimumRate, $maximumRate
         ));
     }
 }

--- a/contracts/ReactionType/Exceptions/ReactionTypeInvalid.php
+++ b/contracts/ReactionType/Exceptions/ReactionTypeInvalid.php
@@ -21,6 +21,9 @@ final class ReactionTypeInvalid extends RuntimeException implements
 {
     public static function nameNotExists(string $name): self
     {
-        return new static("ReactionType with name `{$name}` not exists.");
+        return new self(sprintf(
+            'ReactionType with name `%s` not exists.',
+            $name
+        ));
     }
 }

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -100,7 +100,7 @@ final class Reaction extends Model implements
         ?float $rate
     ): void {
         if (!is_null($rate) && ($rate < self::RATE_MIN || $rate > self::RATE_MAX)) {
-            throw RateOutOfRange::withValue($rate);
+            throw RateOutOfRange::withValueBetween($rate, self::RATE_MIN, self::RATE_MAX);
         }
 
         $this->attributes['rate'] = $rate;


### PR DESCRIPTION
Exception `Cog\Contracts\Love\Reaction\Exceptions\RateOutOfRange` shouldn't depend on concrete `Cog\Laravel\Love\Reaction\Models\Reaction` class.

If you implemented `Cog\Contracts\Love\Reaction\Models\Reaction` interface by yourself - this change will be breaking. It will be done in minor release because it's fixing contracts dependencies issue.