### PR TITLE
Fix Reacter model's hasReactedTo & hasNotReactedTo methods signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#110]) Renamed `withValue` method to `withValueBetween` in `RateOutOfRange` exception
 - ([#110]) Added `$minimumRate` parameter to `withValueBetween` method in `RateOutOfRange` exception
 - ([#110]) Added `$maximumRate` parameter to `withValueBetween` method in `RateOutOfRange` exception
+- ([#111]) Changed `$rate` parameter type from `float` to `?float` of `hasReactedTo` method in `Reacter` model contract
+- ([#111]) Changed `$rate` parameter type from `float` to `?float` of `hasNotReactedTo` method in `Reacter` model contract
 
 ## [8.0.0] - 2019-08-08
 
@@ -407,6 +409,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#111]: https://github.com/cybercog/laravel-love/pull/111
 [#110]: https://github.com/cybercog/laravel-love/pull/110
 [#102]: https://github.com/cybercog/laravel-love/pull/102
 [#100]: https://github.com/cybercog/laravel-love/pull/100

--- a/contracts/Reacter/Models/Reacter.php
+++ b/contracts/Reacter/Models/Reacter.php
@@ -32,9 +32,9 @@ interface Reacter
 
     public function unreactTo(Reactant $reactant, ReactionType $reactionType): void;
 
-    public function hasReactedTo(Reactant $reactant, ?ReactionType $reactionType = null, float $rate = null): bool;
+    public function hasReactedTo(Reactant $reactant, ?ReactionType $reactionType = null, ?float $rate = null): bool;
 
-    public function hasNotReactedTo(Reactant $reactant, ?ReactionType $reactionType = null, float $rate = null): bool;
+    public function hasNotReactedTo(Reactant $reactant, ?ReactionType $reactionType = null, ?float $rate = null): bool;
 
     public function isEqualTo(self $that): bool;
 

--- a/src/Reacter/Models/NullReacter.php
+++ b/src/Reacter/Models/NullReacter.php
@@ -65,7 +65,7 @@ final class NullReacter implements
     public function hasReactedTo(
         Reactant $reactant,
         ?ReactionType $reactionType = null,
-        float $rate = null
+        ?float $rate = null
     ): bool {
         return false;
     }
@@ -73,7 +73,7 @@ final class NullReacter implements
     public function hasNotReactedTo(
         Reactant $reactant,
         ?ReactionType $reactionType = null,
-        float $rate = null
+        ?float $rate = null
     ): bool {
         return true;
     }

--- a/src/Reacter/Models/Reacter.php
+++ b/src/Reacter/Models/Reacter.php
@@ -121,7 +121,7 @@ final class Reacter extends Model implements
     public function hasReactedTo(
         ReactantContract $reactant,
         ?ReactionTypeContract $reactionType = null,
-        float $rate = null
+        ?float $rate = null
     ): bool {
         if ($reactant->isNull()) {
             return false;
@@ -133,7 +133,7 @@ final class Reacter extends Model implements
     public function hasNotReactedTo(
         ReactantContract $reactant,
         ?ReactionTypeContract $reactionType = null,
-        float $rate = null
+        ?float $rate = null
     ): bool {
         return $reactant->isNotReactedBy($this, $reactionType, $rate);
     }
@@ -164,7 +164,7 @@ final class Reacter extends Model implements
     private function createReaction(
         ReactantContract $reactant,
         ReactionTypeContract $reactionType,
-        ?float $rate
+        ?float $rate = null
     ): void {
         $this->reactions()->create([
             'reaction_type_id' => $reactionType->getId(),


### PR DESCRIPTION
For the consistency reason change `float $rate = null` parameter to `?float $rate = null` in `Reacter` models.

Despite the fact this PR changes the contract - it will be released in minor version because it's fully backward compatible.