### PR TITLE
Add Laravel v6 support to Love v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor/
 .php_cs.cache
+.phpunit.result.cache
 composer.lock
 composer.phar
 phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -45,15 +45,15 @@
     },
     "require": {
         "php": "^7.0",
-        "illuminate/database": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0"
+        "illuminate/database": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",
         "mockery/mockery": "^1.0",
-        "orchestra/database": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
-        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
-        "phpunit/phpunit": "^6.0|^7.0"
+        "orchestra/database": "~3.5.0|~3.6.0|~3.7.0|~3.8.0|^4.0",
+        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0|^4.0",
+        "phpunit/phpunit": "^6.0|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -137,7 +137,6 @@ abstract class TestCase extends Orchestra
         Relation::morphMap([
             'entity-with-morph-map' => EntityWithMorphMap::class,
         ]);
-        
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -103,9 +103,7 @@ abstract class TestCase extends Orchestra
      */
     protected function migrateUnitTestTables(): void
     {
-        $this->loadMigrationsFrom([
-            '--realpath' => realpath(__DIR__ . '/database/migrations'),
-        ]);
+        $this->loadMigrationsFrom(__DIR__ . '/database/migrations');
     }
 
     /**
@@ -115,9 +113,7 @@ abstract class TestCase extends Orchestra
      */
     protected function migratePackageTables(): void
     {
-        $this->loadMigrationsFrom([
-            '--realpath' => database_path('migrations'),
-        ]);
+        $this->loadMigrationsFrom(database_path('migrations'));
     }
 
     /**
@@ -141,6 +137,7 @@ abstract class TestCase extends Orchestra
         Relation::morphMap([
             'entity-with-morph-map' => EntityWithMorphMap::class,
         ]);
+        
     }
 
     /**


### PR DESCRIPTION
This PR adds Laravel 6.x support to Laravel Love v5