### PR TITLE
Fix custom connection in database migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ## [Unreleased]
 
+## [8.1.1] - 2019-09-13
+
+### Fixed
+
+- ([#118]) Fix custom connection in database migrations
+
 ## [8.1.0] - 2019-09-03
 
 ### Added
@@ -389,7 +395,8 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 
 - Initial release
 
-[Unreleased]: https://github.com/cybercog/laravel-love/compare/8.1.0...master
+[Unreleased]: https://github.com/cybercog/laravel-love/compare/8.1.1...master
+[8.1.0]: https://github.com/cybercog/laravel-love/compare/8.1.0...8.1.1
 [8.1.0]: https://github.com/cybercog/laravel-love/compare/8.0.0...8.1.0
 [8.0.0]: https://github.com/cybercog/laravel-love/compare/7.2.1...8.0.0
 [7.2.1]: https://github.com/cybercog/laravel-love/compare/7.2.0...7.2.1
@@ -424,6 +431,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#118]: https://github.com/cybercog/laravel-love/pull/118
 [#114]: https://github.com/cybercog/laravel-love/pull/114
 [#113]: https://github.com/cybercog/laravel-love/pull/113
 [#111]: https://github.com/cybercog/laravel-love/pull/111

--- a/database/migrations/2018_07_22_000100_create_love_reacters_table.php
+++ b/database/migrations/2018_07_22_000100_create_love_reacters_table.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 final class CreateLoveReactersTable extends Migration
 {
@@ -24,7 +23,7 @@ final class CreateLoveReactersTable extends Migration
      */
     public function up(): void
     {
-        Schema::create('love_reacters', function (Blueprint $table) {
+        $this->schema->create('love_reacters', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('type');
             $table->timestamps();
@@ -40,6 +39,6 @@ final class CreateLoveReactersTable extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('love_reacters');
+        $this->schema->dropIfExists('love_reacters');
     }
 }

--- a/database/migrations/2018_07_22_001000_create_love_reactants_table.php
+++ b/database/migrations/2018_07_22_001000_create_love_reactants_table.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 final class CreateLoveReactantsTable extends Migration
 {
@@ -24,7 +23,7 @@ final class CreateLoveReactantsTable extends Migration
      */
     public function up(): void
     {
-        Schema::create('love_reactants', function (Blueprint $table) {
+        $this->schema->create('love_reactants', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('type');
             $table->timestamps();
@@ -40,6 +39,6 @@ final class CreateLoveReactantsTable extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('love_reactants');
+        $this->schema->dropIfExists('love_reactants');
     }
 }

--- a/database/migrations/2018_07_22_001500_create_love_reaction_types_table.php
+++ b/database/migrations/2018_07_22_001500_create_love_reaction_types_table.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 final class CreateLoveReactionTypesTable extends Migration
 {
@@ -24,7 +23,7 @@ final class CreateLoveReactionTypesTable extends Migration
      */
     public function up(): void
     {
-        Schema::create('love_reaction_types', function (Blueprint $table) {
+        $this->schema->create('love_reaction_types', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
             $table->tinyInteger('mass');
@@ -41,6 +40,6 @@ final class CreateLoveReactionTypesTable extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('love_reaction_types');
+        $this->schema->dropIfExists('love_reaction_types');
     }
 }

--- a/database/migrations/2018_07_22_002000_create_love_reactions_table.php
+++ b/database/migrations/2018_07_22_002000_create_love_reactions_table.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 final class CreateLoveReactionsTable extends Migration
 {
@@ -24,7 +23,7 @@ final class CreateLoveReactionsTable extends Migration
      */
     public function up(): void
     {
-        Schema::create('love_reactions', function (Blueprint $table) {
+        $this->schema->create('love_reactions', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('reacter_id');
@@ -75,6 +74,6 @@ final class CreateLoveReactionsTable extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('love_reactions');
+        $this->schema->dropIfExists('love_reactions');
     }
 }

--- a/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
+++ b/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 final class CreateLoveReactantReactionCountersTable extends Migration
 {
@@ -24,7 +23,7 @@ final class CreateLoveReactantReactionCountersTable extends Migration
      */
     public function up(): void
     {
-        Schema::create('love_reactant_reaction_counters', function (Blueprint $table) {
+        $this->schema->create('love_reactant_reaction_counters', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('reaction_type_id');
@@ -57,6 +56,6 @@ final class CreateLoveReactantReactionCountersTable extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('love_reactant_reaction_counters');
+        $this->schema->dropIfExists('love_reactant_reaction_counters');
     }
 }

--- a/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
+++ b/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 final class CreateLoveReactantReactionTotalsTable extends Migration
 {
@@ -24,7 +23,7 @@ final class CreateLoveReactantReactionTotalsTable extends Migration
      */
     public function up(): void
     {
-        Schema::create('love_reactant_reaction_totals', function (Blueprint $table) {
+        $this->schema->create('love_reactant_reaction_totals', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('count');
@@ -46,6 +45,6 @@ final class CreateLoveReactantReactionTotalsTable extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('love_reactant_reaction_totals');
+        $this->schema->dropIfExists('love_reactant_reaction_totals');
     }
 }

--- a/src/Console/Commands/SetupReactable.php
+++ b/src/Console/Commands/SetupReactable.php
@@ -87,10 +87,11 @@ final class SetupReactable extends Command
 
         $table = $model->getTable();
         $referencedModel = new Reactant();
+        $referencedSchema = Schema::connection($referencedModel->getConnectionName());
         $referencedTable = $referencedModel->getTable();
         $referencedColumn = $referencedModel->getKeyName();
 
-        if (!Schema::hasTable($referencedTable)) {
+        if (!$referencedSchema->hasTable($referencedTable)) {
             $this->error(sprintf(
                 'Referenced table `%s` does not exists in database.',
                 $referencedTable

--- a/src/Console/Commands/SetupReacterable.php
+++ b/src/Console/Commands/SetupReacterable.php
@@ -22,7 +22,6 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Console/Commands/SetupReacterable.php
+++ b/src/Console/Commands/SetupReacterable.php
@@ -22,6 +22,7 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
@@ -87,10 +88,11 @@ final class SetupReacterable extends Command
 
         $table = $model->getTable();
         $referencedModel = new Reacter();
+        $referencedSchema = Schema::connection($referencedModel->getConnectionName());
         $referencedTable = $referencedModel->getTable();
         $referencedColumn = $referencedModel->getKeyName();
 
-        if (!Schema::hasTable($referencedTable)) {
+        if (!$referencedSchema->hasTable($referencedTable)) {
             $this->error(sprintf(
                 'Referenced table `%s` does not exists in database.',
                 $referencedTable

--- a/src/Support/Database/Migration.php
+++ b/src/Support/Database/Migration.php
@@ -15,9 +15,22 @@ namespace Cog\Laravel\Love\Support\Database;
 
 use Illuminate\Database\Migrations\Migration as IlluminateMigration;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Schema;
 
 abstract class Migration extends IlluminateMigration
 {
+    /**
+     * The database schema.
+     *
+     * @var \Illuminate\Support\Facades\Schema
+     */
+    protected $schema;
+
+    public function __construct()
+    {
+        $this->schema = Schema::connection($this->getConnection());
+    }
+
     /**
      * Get the migration connection name.
      *


### PR DESCRIPTION
Resolves #116 

@vesper8 found that Migration's `getConnection()` method is used only for resolving if connection supports schema transactions, but never used in migration itself.

```php
protected function runMigration($migration, $method)
{
    $connection = $this->resolveConnection(
        $migration->getConnection()
    );

    $callback = function () use ($migration, $method) {
        if (method_exists($migration, $method)) {
            $this->fireMigrationEvent(new MigrationStarted($migration, $method));

            $migration->{$method}();

            $this->fireMigrationEvent(new MigrationEnded($migration, $method));
        }
    };

    $this->getSchemaGrammar($connection)->supportsSchemaTransactions()
        && $migration->withinTransaction
                ? $connection->transaction($callback)
                : $callback();
}
```

So I've added protected `$schema` property with configured connection.

Additionally this PR fixes missing Schema configuration in `love:setup-reacterable` & `love:setup-reactable` commands.