### PR TITLE
Optional ShouldQueue Behavior v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "volkv/laravel-love",
+    "name": "cybercog/laravel-love",
     "description": "Make Laravel Eloquent models reactable with any type of emotions in a minutes!",
     "type": "library",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "cybercog/laravel-love",
+    "name": "volkv/laravel-love",
     "description": "Make Laravel Eloquent models reactable with any type of emotions in a minutes!",
     "type": "library",
     "license": "MIT",

--- a/config/love.php
+++ b/config/love.php
@@ -42,4 +42,15 @@ return [
 
     'load_default_migrations' => true,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Connection Driver
+    |--------------------------------------------------------------------------
+    |
+    | You may overwrite global QUEUE_CONNECTION driver here
+    |
+    */
+
+    'queue_connection' => null,
+
 ];

--- a/src/Reactant/Listeners/DecrementAggregates.php
+++ b/src/Reactant/Listeners/DecrementAggregates.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\Listeners;
 
+use Cog\Laravel\Love\Reactant\Listeners\Traits\OptionalQueueConnection;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Services\ReactionCounterService;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Services\ReactionTotalService;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenRemoved;
@@ -20,6 +21,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 
 final class DecrementAggregates implements ShouldQueue
 {
+    use OptionalQueueConnection;
     /**
      * Handle the event.
      *

--- a/src/Reactant/Listeners/IncrementAggregates.php
+++ b/src/Reactant/Listeners/IncrementAggregates.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\Listeners;
 
+use Cog\Laravel\Love\Reactant\Listeners\Traits\OptionalQueueConnection;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Services\ReactionCounterService;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Services\ReactionTotalService;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenAdded;
@@ -20,6 +21,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 
 final class IncrementAggregates implements ShouldQueue
 {
+    use OptionalQueueConnection;
     /**
      * Handle the event.
      *

--- a/src/Reactant/Listeners/Traits/OptionalQueueConnection.php
+++ b/src/Reactant/Listeners/Traits/OptionalQueueConnection.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Cog\Laravel\Love\Reactant\Listeners\Traits;
+
+use Illuminate\Support\Facades\Config;
+
+Trait OptionalQueueConnection
+{
+    public function __get($name)
+    {
+        if ($name == 'connection') {
+            return Config::get('love.queue_connection', null);
+        }
+    }
+}


### PR DESCRIPTION
> There is no need to create separate Listener without ShouldQueue interface. I'm sure there is a way how we could set queue connection to `sync` on the fly.

That ShouldQueue listeners is a bit tricky, they are not going to IoC container so its not possible to rebind them. 
There is a public property $connection but you cant set it on __construct cuz it goes throw
`$listener = (new ReflectionClass($class))->newInstanceWithoutConstructor();`
The previous approach was a bit straightforward and non-OOP way but it did its job without 'hacks'
This one is another - a bit dirtier, but minimal.
So please choose one or tell your ideas