### PR TITLE
Extract event listeners registering to LoveEventServiceProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `laravel-love` will be documented in this file.
 
 - ([#146]) Extracted logic from `Cog\Laravel\Love\Reactant\Listeners\IncrementAggregates` listener to `Cog\Laravel\Love\Reactant\Jobs\IncrementAggregatesJob`
 - ([#146]) Extracted logic from `Cog\Laravel\Love\Reactant\Listeners\DecrementAggregates` listener to `Cog\Laravel\Love\Reactant\Jobs\DecrementAggregatesJob`
+- ([#147]) Extracted event listeners registering from `Cog\Laravel\Love\LoveServiceProvider` to `Cog\Laravel\Love\LoveEventServiceProvider`
 
 ## [8.2.0] - 2020-01-30
 
@@ -448,6 +449,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#147]: https://github.com/cybercog/laravel-love/pull/147
 [#146]: https://github.com/cybercog/laravel-love/pull/146
 [#127]: https://github.com/cybercog/laravel-love/pull/127
 [#121]: https://github.com/cybercog/laravel-love/pull/121

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,8 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Cog\\Laravel\\Love\\LoveServiceProvider"
+                "Cog\\Laravel\\Love\\LoveServiceProvider",
+                "Cog\\Laravel\\Love\\LoveEventServiceProvider"
             ]
         }
     },

--- a/src/LoveEventServiceProvider.php
+++ b/src/LoveEventServiceProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Laravel Love.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Laravel\Love;
+
+use Cog\Laravel\Love\Reactant\Listeners\DecrementAggregates;
+use Cog\Laravel\Love\Reactant\Listeners\IncrementAggregates;
+use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenAdded;
+use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenRemoved;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\ServiceProvider;
+
+final class LoveEventServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application events.
+     *
+     * @return void
+     */
+    public function boot(): void
+    {
+        $this->registerListeners();
+    }
+
+    /**
+     * Register the Love event listeners.
+     *
+     * @return void
+     */
+    private function registerListeners(): void
+    {
+        Event::listen(ReactionHasBeenAdded::class, IncrementAggregates::class);
+        Event::listen(ReactionHasBeenRemoved::class, DecrementAggregates::class);
+    }
+}

--- a/src/LoveServiceProvider.php
+++ b/src/LoveServiceProvider.php
@@ -21,18 +21,13 @@ use Cog\Laravel\Love\Console\Commands\SetupReactable;
 use Cog\Laravel\Love\Console\Commands\SetupReacterable;
 use Cog\Laravel\Love\Console\Commands\UpgradeV5ToV6;
 use Cog\Laravel\Love\Console\Commands\UpgradeV7ToV8;
-use Cog\Laravel\Love\Reactant\Listeners\DecrementAggregates;
-use Cog\Laravel\Love\Reactant\Listeners\IncrementAggregates;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Observers\ReactionCounterObserver;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Observers\ReactionTotalObserver;
-use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenAdded;
-use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenRemoved;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
 use Cog\Laravel\Love\Reaction\Observers\ReactionObserver;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 final class LoveServiceProvider extends ServiceProvider
@@ -58,7 +53,6 @@ final class LoveServiceProvider extends ServiceProvider
         $this->registerObservers();
         $this->registerPublishes();
         $this->registerMigrations();
-        $this->registerListeners();
     }
 
     /**
@@ -132,17 +126,6 @@ final class LoveServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole() && $this->shouldLoadDefaultMigrations()) {
             $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
         }
-    }
-
-    /**
-     * Register the Love event listeners.
-     *
-     * @return void
-     */
-    private function registerListeners(): void
-    {
-        Event::listen(ReactionHasBeenAdded::class, IncrementAggregates::class);
-        Event::listen(ReactionHasBeenRemoved::class, DecrementAggregates::class);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love;
 
+use Cog\Laravel\Love\LoveEventServiceProvider;
 use Cog\Laravel\Love\LoveServiceProvider;
 use Cog\Tests\Laravel\Love\Stubs\Models\MorphMappedReactable;
 use Cog\Tests\Laravel\Love\Stubs\Models\MorphMappedReacterable;
@@ -62,6 +63,7 @@ abstract class TestCase extends OrchestraTestCase
     {
         return [
             LoveServiceProvider::class,
+            LoveEventServiceProvider::class,
             ConsoleServiceProvider::class,
         ];
     }


### PR DESCRIPTION
Second part of configurable events behavior concept #145 

In this PR I've extracted event listeners registering from `Cog\Laravel\Love\LoveServiceProvider` to separate `Cog\Laravel\Love\LoveEventServiceProvider` class.

Resolves #139 