### PR TITLE
Extract Reactant reactions recounting logic to RebuildReactionAggregatesJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ### Fixed
 
-- ([#148]) Fixed `love:recount` Artisan command execution when `reaction_totals` database table is empty
+- ([#148]) Fixed `love:recount` Artisan command execution when `love_reactant_reaction_totals` database table is empty
 
 ## [8.2.0] - 2020-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#146]) Extracted logic from `Cog\Laravel\Love\Reactant\Listeners\DecrementAggregates` listener to `Cog\Laravel\Love\Reactant\Jobs\DecrementReactionAggregatesJob`
 - ([#147]) Extracted event listeners registering from `Cog\Laravel\Love\LoveServiceProvider` to `Cog\Laravel\Love\LoveEventServiceProvider`
 - ([#148]) Extracted rebuild of reactant reactions counters from `Cog\Laravel\Love\Console\Commands\Recount` command to `Cog\Laravel\Love\Reactant\Jobs\RebuildReactionAggregatesJob`
+- ([#148]) Added `--queue-connection=` option to `love:recount` Artisan command
 
 ## [8.2.0] - 2020-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#148]) Extracted rebuild of reactant reactions counters from `Cog\Laravel\Love\Console\Commands\Recount` command to `Cog\Laravel\Love\Reactant\Jobs\RebuildReactionAggregatesJob`
 - ([#148]) Added `--queue-connection=` option to `love:recount` Artisan command
 
+### Fixed
+
+- ([#148]) Fixed `love:recount` Artisan command execution when `reaction_totals` database table is empty
+
 ## [8.2.0] - 2020-01-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
 - ([#146]) Extracted logic from `Cog\Laravel\Love\Reactant\Listeners\IncrementAggregates` listener to `Cog\Laravel\Love\Reactant\Jobs\IncrementAggregatesJob`
 - ([#146]) Extracted logic from `Cog\Laravel\Love\Reactant\Listeners\DecrementAggregates` listener to `Cog\Laravel\Love\Reactant\Jobs\DecrementAggregatesJob`
 - ([#147]) Extracted event listeners registering from `Cog\Laravel\Love\LoveServiceProvider` to `Cog\Laravel\Love\LoveEventServiceProvider`
+- ([#148]) Extracted rebuild of reactant reactions counters from `Cog\Laravel\Love\Console\Commands\Recount` command to `Cog\Laravel\Love\Reactant\Jobs\RebuildReactionAggregatesJob`
 
 ## [8.2.0] - 2020-01-30
 
@@ -449,6 +452,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#148]: https://github.com/cybercog/laravel-love/pull/148
 [#147]: https://github.com/cybercog/laravel-love/pull/147
 [#146]: https://github.com/cybercog/laravel-love/pull/146
 [#127]: https://github.com/cybercog/laravel-love/pull/127

--- a/src/Console/Commands/Recount.php
+++ b/src/Console/Commands/Recount.php
@@ -49,6 +49,7 @@ final class Recount extends Command
         return [
             ['model', null, InputOption::VALUE_OPTIONAL, 'The name of the reactable model'],
             ['type', null, InputOption::VALUE_OPTIONAL, 'The name of the reaction type'],
+            ['queue-connection', null, InputOption::VALUE_OPTIONAL, 'The name of the queue connection'],
         ];
     }
 
@@ -76,12 +77,15 @@ final class Recount extends Command
             $reactionType = ReactionType::fromName($reactionType);
         }
 
+        $queueConnectionName = $this->option('queue-connection');
+
         $reactants = $this->collectReactants($reactableType);
 
         $this->getOutput()->progressStart($reactants->count());
         foreach ($reactants as $reactant) {
             $this->dispatcher->dispatch(
-                new RebuildAggregatesJob($reactant, $reactionType)
+                (new RebuildAggregatesJob($reactant, $reactionType))
+                    ->onConnection($queueConnectionName)
             );
 
             $this->getOutput()->progressAdvance();

--- a/src/Console/Commands/Recount.php
+++ b/src/Console/Commands/Recount.php
@@ -54,8 +54,7 @@ final class Recount extends Command
 
     public function __construct(
         Dispatcher $dispatcher
-    )
-    {
+    ) {
         parent::__construct();
         $this->dispatcher = $dispatcher;
     }

--- a/src/Console/Commands/Recount.php
+++ b/src/Console/Commands/Recount.php
@@ -15,7 +15,7 @@ namespace Cog\Laravel\Love\Console\Commands;
 
 use Cog\Contracts\Love\Reactable\Exceptions\ReactableInvalid;
 use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
-use Cog\Laravel\Love\Reactant\Jobs\RebuildAggregatesJob;
+use Cog\Laravel\Love\Reactant\Jobs\RebuildReactionAggregatesJob;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Illuminate\Console\Command;
@@ -84,7 +84,7 @@ final class Recount extends Command
         $this->getOutput()->progressStart($reactants->count());
         foreach ($reactants as $reactant) {
             $this->dispatcher->dispatch(
-                (new RebuildAggregatesJob($reactant, $reactionType))
+                (new RebuildReactionAggregatesJob($reactant, $reactionType))
                     ->onConnection($queueConnectionName)
             );
 

--- a/src/Console/Commands/Recount.php
+++ b/src/Console/Commands/Recount.php
@@ -44,8 +44,8 @@ final class Recount extends Command
      */
     private $dispatcher;
 
-    protected function getOptions(): array
-    {
+    protected function getOptions(
+    ): array {
         return [
             ['model', null, InputOption::VALUE_OPTIONAL, 'The name of the reactable model'],
             ['type', null, InputOption::VALUE_OPTIONAL, 'The name of the reaction type'],

--- a/src/Reactant/Jobs/RebuildAggregatesJob.php
+++ b/src/Reactant/Jobs/RebuildAggregatesJob.php
@@ -59,6 +59,19 @@ final class RebuildAggregatesJob implements
         $this->recountTotal($this->reactant);
     }
 
+    private function recountCounters(
+        ReactantContract $reactant
+    ): void {
+        $this->resetCountersValues();
+
+        $service = new ReactionCounterService($reactant);
+
+        $reactions = $this->collectReactions();
+        foreach ($reactions as $reaction) {
+            $service->addReaction($reaction);
+        }
+    }
+
     private function recountTotal(
         ReactantContract $reactant
     ): void {
@@ -83,19 +96,6 @@ final class RebuildAggregatesJob implements
             'count' => $totalCount,
             'weight' => $totalWeight,
         ]);
-    }
-
-    private function recountCounters(
-        ReactantContract $reactant
-    ): void {
-        $this->resetCountersValues();
-
-        $service = new ReactionCounterService($reactant);
-
-        $reactions = $this->collectReactions();
-        foreach ($reactions as $reaction) {
-            $service->addReaction($reaction);
-        }
     }
 
     /**
@@ -136,20 +136,6 @@ final class RebuildAggregatesJob implements
     }
 
     /**
-     * Determine if counter should not be rebuilt.
-     *
-     * @param ReactionCounterContract $counter
-     * @return bool
-     */
-    private function shouldNotAffectCounter(
-        ReactionCounterContract $counter
-    ): bool
-    {
-        return $this->reactionType !== null
-            && $counter->isNotReactionOfType($this->reactionType);
-    }
-
-    /**
      * @return \Illuminate\Database\Eloquent\Builder[]|\Illuminate\Database\Eloquent\Collection
      */
     private function collectReactions(
@@ -162,5 +148,18 @@ final class RebuildAggregatesJob implements
         }
 
         return $query->get();
+    }
+
+    /**
+     * Determine if counter should not be rebuilt.
+     *
+     * @param ReactionCounterContract $counter
+     * @return bool
+     */
+    private function shouldNotAffectCounter(
+        ReactionCounterContract $counter
+    ): bool {
+        return $this->reactionType !== null
+            && $counter->isNotReactionOfType($this->reactionType);
     }
 }

--- a/src/Reactant/Jobs/RebuildAggregatesJob.php
+++ b/src/Reactant/Jobs/RebuildAggregatesJob.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of Laravel Love.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Laravel\Love\Reactant\Jobs;
+
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
+use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalContract;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
+use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
+use Cog\Laravel\Love\Reactant\ReactionCounter\Services\ReactionCounterService;
+use Cog\Laravel\Love\Reactant\ReactionTotal\Models\NullReactionTotal;
+use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+final class RebuildAggregatesJob implements
+    ShouldQueue
+{
+    use Dispatchable;
+    use Queueable;
+
+    /**
+     * @var \Cog\Contracts\Love\Reactant\Models\Reactant
+     */
+    private $reactant;
+
+    /**
+     * @var \Cog\Contracts\Love\ReactionType\Models\ReactionType|null
+     */
+    private $reactionType;
+
+    /**
+     * @param \Cog\Contracts\Love\Reactant\Models\Reactant $reactant
+     * @param \Cog\Contracts\Love\ReactionType\Models\ReactionType|null $reactionType
+     */
+    public function __construct(
+        ReactantContract $reactant,
+        ?ReactionTypeContract $reactionType = null
+    ) {
+        $this->reactant = $reactant;
+        $this->reactionType = $reactionType;
+    }
+
+    public function handle(
+    ): void {
+        /** @var \Illuminate\Database\Eloquent\Builder $query */
+        $query = $this->reactant->reactions();
+
+        if ($this->reactionType !== null) {
+            $query->where('reaction_type_id', $this->reactionType->getId());
+        }
+
+        $counters = $this->reactant->getReactionCounters();
+
+        /** @var \Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter $counter */
+        foreach ($counters as $counter) {
+            if ($this->reactionType && $counter->isNotReactionOfType($this->reactionType)) {
+                continue;
+            }
+
+            $counter->update([
+                'count' => ReactionCounter::COUNT_DEFAULT,
+                'weight' => ReactionCounter::WEIGHT_DEFAULT,
+            ]);
+        }
+
+        $reactions = $query->get();
+        $this->recountCounters($this->reactant, $reactions);
+        $this->recountTotal($this->reactant);
+    }
+
+    private function recountTotal(
+        ReactantContract $reactant
+    ): void {
+        $counters = $reactant->getReactionCounters();
+
+        if (count($counters) === 0) {
+            return;
+        }
+
+        $totalCount = ReactionTotal::COUNT_DEFAULT;
+        $totalWeight = ReactionTotal::WEIGHT_DEFAULT;
+
+        foreach ($counters as $counter) {
+            $totalCount += $counter->getCount();
+            $totalWeight += $counter->getWeight();
+        }
+
+        /** @var \Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal $reactionTotal */
+        $reactionTotal = $this->findOrCreateReactionTotal($reactant);
+
+        $reactionTotal->update([
+            'count' => $totalCount,
+            'weight' => $totalWeight,
+        ]);
+    }
+
+    private function recountCounters(
+        ReactantContract $reactant,
+        iterable $reactions
+    ): void {
+        $service = new ReactionCounterService($reactant);
+
+        foreach ($reactions as $reaction) {
+            $service->addReaction($reaction);
+        }
+    }
+
+    /**
+     * @param \Cog\Contracts\Love\Reactant\Models\Reactant $reactant
+     * @return \Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal
+     */
+    private function findOrCreateReactionTotal(
+        ReactantContract $reactant
+    ): ReactionTotalContract {
+        $reactionTotal = $reactant->getReactionTotal();
+
+        if ($reactionTotal instanceof NullReactionTotal) {
+            $reactant->createReactionTotal();
+            $reactionTotal = $reactant->getReactionTotal();
+        }
+
+        return $reactionTotal;
+    }
+}

--- a/src/Reactant/Jobs/RebuildAggregatesJob.php
+++ b/src/Reactant/Jobs/RebuildAggregatesJob.php
@@ -51,16 +51,15 @@ final class RebuildAggregatesJob implements
 
     public function handle(
     ): void {
-        $this->recountReactionCounters($this->reactant);
-        $this->recountReactionTotal($this->reactant);
+        $this->recountReactionCounters();
+        $this->recountReactionTotal();
     }
 
     private function recountReactionCounters(
-        ReactantContract $reactant
     ): void {
         $this->resetCountersValues();
 
-        $service = new ReactionCounterService($reactant);
+        $service = new ReactionCounterService($this->reactant);
 
         $reactions = $this->collectReactions();
         foreach ($reactions as $reaction) {
@@ -69,9 +68,8 @@ final class RebuildAggregatesJob implements
     }
 
     private function recountReactionTotal(
-        ReactantContract $reactant
     ): void {
-        $counters = $reactant->getReactionCounters();
+        $counters = $this->reactant->getReactionCounters();
 
         if (count($counters) === 0) {
             return;
@@ -85,7 +83,7 @@ final class RebuildAggregatesJob implements
             $totalWeight += $counter->getWeight();
         }
 
-        $reactionTotal = $this->findOrCreateReactionTotal($reactant);
+        $reactionTotal = $this->findOrCreateReactionTotal();
 
         /** @var \Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal $reactionTotal */
         $reactionTotal->update([
@@ -95,13 +93,12 @@ final class RebuildAggregatesJob implements
     }
 
     private function findOrCreateReactionTotal(
-        ReactantContract $reactant
     ): ReactionTotalContract {
-        $reactionTotal = $reactant->getReactionTotal();
+        $reactionTotal = $this->reactant->getReactionTotal();
 
         if ($reactionTotal instanceof NullReactionTotal) {
-            $reactant->createReactionTotal();
-            $reactionTotal = $reactant->getReactionTotal();
+            $this->reactant->createReactionTotal();
+            $reactionTotal = $this->reactant->getReactionTotal();
         }
 
         return $reactionTotal;

--- a/src/Reactant/Jobs/RebuildAggregatesJob.php
+++ b/src/Reactant/Jobs/RebuildAggregatesJob.php
@@ -41,10 +41,6 @@ final class RebuildAggregatesJob implements
      */
     private $reactionType;
 
-    /**
-     * @param \Cog\Contracts\Love\Reactant\Models\Reactant $reactant
-     * @param \Cog\Contracts\Love\ReactionType\Models\ReactionType|null $reactionType
-     */
     public function __construct(
         ReactantContract $reactant,
         ?ReactionTypeContract $reactionType = null
@@ -55,11 +51,11 @@ final class RebuildAggregatesJob implements
 
     public function handle(
     ): void {
-        $this->recountCounters($this->reactant);
-        $this->recountTotal($this->reactant);
+        $this->recountReactionCounters($this->reactant);
+        $this->recountReactionTotal($this->reactant);
     }
 
-    private function recountCounters(
+    private function recountReactionCounters(
         ReactantContract $reactant
     ): void {
         $this->resetCountersValues();
@@ -72,7 +68,7 @@ final class RebuildAggregatesJob implements
         }
     }
 
-    private function recountTotal(
+    private function recountReactionTotal(
         ReactantContract $reactant
     ): void {
         $counters = $reactant->getReactionCounters();
@@ -98,10 +94,6 @@ final class RebuildAggregatesJob implements
         ]);
     }
 
-    /**
-     * @param \Cog\Contracts\Love\Reactant\Models\Reactant $reactant
-     * @return \Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal
-     */
     private function findOrCreateReactionTotal(
         ReactantContract $reactant
     ): ReactionTotalContract {
@@ -115,9 +107,6 @@ final class RebuildAggregatesJob implements
         return $reactionTotal;
     }
 
-    /**
-     * @return void
-     */
     private function resetCountersValues(
     ): void {
         $counters = $this->reactant->getReactionCounters();

--- a/src/Reactant/Jobs/RebuildReactionAggregatesJob.php
+++ b/src/Reactant/Jobs/RebuildReactionAggregatesJob.php
@@ -25,7 +25,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 
-final class RebuildAggregatesJob implements
+final class RebuildReactionAggregatesJob implements
     ShouldQueue
 {
     use Dispatchable;


### PR DESCRIPTION
Resolves #137
Resolves #138

Hey @vesper8! This PR should fix both of your issues. It fixes recounting when counters & totals are not yet exists and allows you to call the command separately from the console command.

For example:
```php
RebuildReactionAggregatesJob::dispatch($reactant, $reactionType);
```

Now it's using queues, so if you want to call it synchronously you could call it on `sync` connection:
```php
RebuildReactionAggregatesJob::dispatch($reactant, $reactionType)
                ->onConnection('sync');
```

Console command will have queue connection option too:
```shell script
$ php artisan love:recount --model="App\User" --queue-connection=redis
```

To keep backward compatibility `sync` connection will be used by default until the next major version.

What do you think about it?