### PR TITLE
Code style fixes for typehints

### DIFF
--- a/src/Console/Commands/Recount.php
+++ b/src/Console/Commands/Recount.php
@@ -19,7 +19,7 @@ use Cog\Laravel\Love\Reactant\Jobs\RebuildReactionAggregatesJob;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -59,7 +59,7 @@ final class Recount extends Command
     }
 
     public function __construct(
-        Dispatcher $dispatcher
+        DispatcherContract $dispatcher
     ) {
         parent::__construct();
         $this->dispatcher = $dispatcher;

--- a/src/Reactant/Facades/Reactant.php
+++ b/src/Reactant/Facades/Reactant.php
@@ -20,7 +20,8 @@ use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTo
 use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 
-final class Reactant implements ReacterFacadeContract
+final class Reactant implements
+    ReacterFacadeContract
 {
     private $reactant;
 

--- a/src/Reactant/Jobs/DecrementReactionAggregatesJob.php
+++ b/src/Reactant/Jobs/DecrementReactionAggregatesJob.php
@@ -18,11 +18,11 @@ use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Services\ReactionCounterService;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Services\ReactionTotalService;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueContract;
 use Illuminate\Foundation\Bus\Dispatchable;
 
 final class DecrementReactionAggregatesJob implements
-    ShouldQueue
+    ShouldQueueContract
 {
     use Dispatchable;
     use Queueable;

--- a/src/Reactant/Jobs/IncrementReactionAggregatesJob.php
+++ b/src/Reactant/Jobs/IncrementReactionAggregatesJob.php
@@ -18,11 +18,11 @@ use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Services\ReactionCounterService;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Services\ReactionTotalService;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueContract;
 use Illuminate\Foundation\Bus\Dispatchable;
 
 final class IncrementReactionAggregatesJob implements
-    ShouldQueue
+    ShouldQueueContract
 {
     use Dispatchable;
     use Queueable;

--- a/src/Reactant/Jobs/RebuildReactionAggregatesJob.php
+++ b/src/Reactant/Jobs/RebuildReactionAggregatesJob.php
@@ -22,11 +22,11 @@ use Cog\Laravel\Love\Reactant\ReactionCounter\Services\ReactionCounterService;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\NullReactionTotal;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueContract;
 use Illuminate\Foundation\Bus\Dispatchable;
 
 final class RebuildReactionAggregatesJob implements
-    ShouldQueue
+    ShouldQueueContract
 {
     use Dispatchable;
     use Queueable;

--- a/src/Reactant/Listeners/DecrementAggregates.php
+++ b/src/Reactant/Listeners/DecrementAggregates.php
@@ -15,17 +15,18 @@ namespace Cog\Laravel\Love\Reactant\Listeners;
 
 use Cog\Laravel\Love\Reactant\Jobs\DecrementReactionAggregatesJob;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenRemoved;
-use Illuminate\Contracts\Bus\Dispatcher;
-use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueContract;
 
-final class DecrementAggregates implements ShouldQueue
+final class DecrementAggregates implements
+    ShouldQueueContract
 {
     /**
      * @var \Illuminate\Contracts\Bus\Dispatcher
      */
     private $dispatcher;
 
-    public function __construct(Dispatcher $dispatcher)
+    public function __construct(DispatcherContract $dispatcher)
     {
         $this->dispatcher = $dispatcher;
     }

--- a/src/Reactant/Listeners/IncrementAggregates.php
+++ b/src/Reactant/Listeners/IncrementAggregates.php
@@ -15,17 +15,18 @@ namespace Cog\Laravel\Love\Reactant\Listeners;
 
 use Cog\Laravel\Love\Reactant\Jobs\IncrementReactionAggregatesJob;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenAdded;
-use Illuminate\Contracts\Bus\Dispatcher;
-use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueContract;
 
-final class IncrementAggregates implements ShouldQueue
+final class IncrementAggregates implements
+    ShouldQueueContract
 {
     /**
      * @var \Illuminate\Contracts\Bus\Dispatcher
      */
     private $dispatcher;
 
-    public function __construct(Dispatcher $dispatcher)
+    public function __construct(DispatcherContract $dispatcher)
     {
         $this->dispatcher = $dispatcher;
     }

--- a/src/Reacter/Facades/Reacter.php
+++ b/src/Reacter/Facades/Reacter.php
@@ -18,7 +18,8 @@ use Cog\Contracts\Love\Reacter\Facades\Reacter as ReacterFacadeContract;
 use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 
-final class Reacter implements ReacterFacadeContract
+final class Reacter implements
+    ReacterFacadeContract
 {
     private $reacter;
 

--- a/src/Reacter/Models/NullReacter.php
+++ b/src/Reacter/Models/NullReacter.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reacter\Models;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
 use Cog\Contracts\Love\Reacter\Exceptions\ReacterInvalid;
 use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
 use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
-use Cog\Contracts\Love\ReactionType\Models\ReactionType;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
 use Illuminate\Support\Collection;
 use TypeError;
 
@@ -48,31 +48,31 @@ final class NullReacter implements
     }
 
     public function reactTo(
-        Reactant $reactant,
-        ReactionType $reactionType,
+        ReactantContract $reactant,
+        ReactionTypeContract $reactionType,
         ?float $rate = null
     ): void {
         throw ReacterInvalid::notExists();
     }
 
     public function unreactTo(
-        Reactant $reactant,
-        ReactionType $reactionType
+        ReactantContract $reactant,
+        ReactionTypeContract $reactionType
     ): void {
         throw ReacterInvalid::notExists();
     }
 
     public function hasReactedTo(
-        Reactant $reactant,
-        ?ReactionType $reactionType = null,
+        ReactantContract $reactant,
+        ?ReactionTypeContract $reactionType = null,
         ?float $rate = null
     ): bool {
         return false;
     }
 
     public function hasNotReactedTo(
-        Reactant $reactant,
-        ?ReactionType $reactionType = null,
+        ReactantContract $reactant,
+        ?ReactionTypeContract $reactionType = null,
         ?float $rate = null
     ): bool {
         return true;


### PR DESCRIPTION
Fixing consistency:
- Each interface import should have `*Contract` postfix.
- Interfaces which are implemented by class should start from the new line.