### PR TITLE
Use DI instead of global event helper method

### DIFF
--- a/src/Reaction/Observers/ReactionObserver.php
+++ b/src/Reaction/Observers/ReactionObserver.php
@@ -22,8 +22,9 @@ final class ReactionObserver
 {
     private $eventDispatcher;
 
-    public function __construct(DispatcherContract $eventDispatcher)
-    {
+    public function __construct(
+        DispatcherContract $eventDispatcher
+    ) {
         $this->eventDispatcher = $eventDispatcher;
     }
 

--- a/src/Reaction/Observers/ReactionObserver.php
+++ b/src/Reaction/Observers/ReactionObserver.php
@@ -16,9 +16,17 @@ namespace Cog\Laravel\Love\Reaction\Observers;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenAdded;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenRemoved;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
 final class ReactionObserver
 {
+    private $eventDispatcher;
+
+    public function __construct(DispatcherContract $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
     public function creating(
         Reaction $reaction
     ): void {
@@ -30,12 +38,16 @@ final class ReactionObserver
     public function created(
         Reaction $reaction
     ): void {
-        event(new ReactionHasBeenAdded($reaction));
+        $this->eventDispatcher->dispatch(
+            new ReactionHasBeenAdded($reaction)
+        );
     }
 
     public function deleted(
         Reaction $reaction
     ): void {
-        event(new ReactionHasBeenRemoved($reaction));
+        $this->eventDispatcher->dispatch(
+            new ReactionHasBeenRemoved($reaction)
+        );
     }
 }


### PR DESCRIPTION
Avoid usage of `event` global helper method.  This PR resolves event dispatcher in `__construct`.