### PR TITLE
Remove redundant queues from Reactant listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- ([#161]) Removed redundant queues from Reactant listeners
+
 ## [8.3.1] - 2020-03-06
 
 ### Added
@@ -468,6 +472,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#161]: https://github.com/cybercog/laravel-love/pull/161
 [#158]: https://github.com/cybercog/laravel-love/pull/158
 [#151]: https://github.com/cybercog/laravel-love/pull/151
 [#148]: https://github.com/cybercog/laravel-love/pull/148

--- a/src/Reactant/Listeners/DecrementAggregates.php
+++ b/src/Reactant/Listeners/DecrementAggregates.php
@@ -16,10 +16,8 @@ namespace Cog\Laravel\Love\Reactant\Listeners;
 use Cog\Laravel\Love\Reactant\Jobs\DecrementReactionAggregatesJob;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenRemoved;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
-use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueContract;
 
-final class DecrementAggregates implements
-    ShouldQueueContract
+final class DecrementAggregates
 {
     /**
      * @var \Illuminate\Contracts\Bus\Dispatcher

--- a/src/Reactant/Listeners/IncrementAggregates.php
+++ b/src/Reactant/Listeners/IncrementAggregates.php
@@ -16,10 +16,8 @@ namespace Cog\Laravel\Love\Reactant\Listeners;
 use Cog\Laravel\Love\Reactant\Jobs\IncrementReactionAggregatesJob;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenAdded;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
-use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueContract;
 
-final class IncrementAggregates implements
-    ShouldQueueContract
+final class IncrementAggregates
 {
     /**
      * @var \Illuminate\Contracts\Bus\Dispatcher


### PR DESCRIPTION
Queue is not required in listeners because all the logic was moved (#146) to Job classes which are already using queues. This will speed up counters & totals creation and decrease load of your queues.