### PR TITLE
Make model table names configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- ([#165]) Added table names configuration
+
 ### Fixed
 
 - ([#161]) Removed redundant queues from Reactant listeners
@@ -472,6 +476,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#165]: https://github.com/cybercog/laravel-love/pull/165
 [#161]: https://github.com/cybercog/laravel-love/pull/161
 [#158]: https://github.com/cybercog/laravel-love/pull/158
 [#151]: https://github.com/cybercog/laravel-love/pull/151

--- a/config/love.php
+++ b/config/love.php
@@ -27,6 +27,13 @@ return [
     'storage' => [
         'database' => [
             'connection' => env('DB_CONNECTION', 'mysql'),
+            'tables' => [
+                'love_reacters' => null,
+                'love_reactants' => null,
+                'love_reaction_types' => null,
+                'love_reactant_reaction_counters' => null,
+                'love_reactant_reaction_totals' => null,
+            ],
         ],
     ],
 

--- a/config/love.php
+++ b/config/love.php
@@ -31,6 +31,7 @@ return [
                 'love_reacters' => null,
                 'love_reactants' => null,
                 'love_reaction_types' => null,
+                'love_reactions' => null,
                 'love_reactant_reaction_counters' => null,
                 'love_reactant_reaction_totals' => null,
             ],

--- a/database/migrations/2018_07_22_000100_create_love_reacters_table.php
+++ b/database/migrations/2018_07_22_000100_create_love_reacters_table.php
@@ -11,6 +11,7 @@
 
 declare(strict_types=1);
 
+use Cog\Laravel\Love\Reacter\Models\Reacter;
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -23,7 +24,7 @@ final class CreateLoveReactersTable extends Migration
      */
     public function up(): void
     {
-        $this->schema->create('love_reacters', function (Blueprint $table) {
+        $this->schema->create((new Reacter())->getTable(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('type');
             $table->timestamps();
@@ -39,6 +40,6 @@ final class CreateLoveReactersTable extends Migration
      */
     public function down(): void
     {
-        $this->schema->dropIfExists('love_reacters');
+        $this->schema->dropIfExists((new Reacter())->getTable());
     }
 }

--- a/database/migrations/2018_07_22_001000_create_love_reactants_table.php
+++ b/database/migrations/2018_07_22_001000_create_love_reactants_table.php
@@ -11,6 +11,7 @@
 
 declare(strict_types=1);
 
+use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -23,7 +24,8 @@ final class CreateLoveReactantsTable extends Migration
      */
     public function up(): void
     {
-        $this->schema->create('love_reactants', function (Blueprint $table) {
+
+        $this->schema->create((new Reactant)->getTable(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('type');
             $table->timestamps();
@@ -39,6 +41,6 @@ final class CreateLoveReactantsTable extends Migration
      */
     public function down(): void
     {
-        $this->schema->dropIfExists('love_reactants');
+        $this->schema->dropIfExists((new Reactant)->getTable());
     }
 }

--- a/database/migrations/2018_07_22_001000_create_love_reactants_table.php
+++ b/database/migrations/2018_07_22_001000_create_love_reactants_table.php
@@ -24,7 +24,6 @@ final class CreateLoveReactantsTable extends Migration
      */
     public function up(): void
     {
-
         $this->schema->create((new Reactant)->getTable(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('type');

--- a/database/migrations/2018_07_22_001500_create_love_reaction_types_table.php
+++ b/database/migrations/2018_07_22_001500_create_love_reaction_types_table.php
@@ -11,6 +11,7 @@
 
 declare(strict_types=1);
 
+use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -23,7 +24,7 @@ final class CreateLoveReactionTypesTable extends Migration
      */
     public function up(): void
     {
-        $this->schema->create('love_reaction_types', function (Blueprint $table) {
+        $this->schema->create((new ReactionType())->getTable(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
             $table->tinyInteger('mass');
@@ -40,6 +41,6 @@ final class CreateLoveReactionTypesTable extends Migration
      */
     public function down(): void
     {
-        $this->schema->dropIfExists('love_reaction_types');
+        $this->schema->dropIfExists((new ReactionType())->getTable());
     }
 }

--- a/database/migrations/2018_07_22_002000_create_love_reactions_table.php
+++ b/database/migrations/2018_07_22_002000_create_love_reactions_table.php
@@ -35,6 +35,24 @@ final class CreateLoveReactionsTable extends Migration
             $table->decimal('rate', 4, 2);
             $table->timestamps();
 
+            $table->index([
+                'reactant_id',
+                'reaction_type_id',
+            ]);
+            $table->index([
+                'reactant_id',
+                'reacter_id',
+                'reaction_type_id',
+            ]);
+            $table->index([
+                'reactant_id',
+                'reacter_id',
+            ]);
+            $table->index([
+                'reacter_id',
+                'reaction_type_id',
+            ]);
+
             $table
                 ->foreign('reactant_id')
                 ->references('id')

--- a/database/migrations/2018_07_22_002000_create_love_reactions_table.php
+++ b/database/migrations/2018_07_22_002000_create_love_reactions_table.php
@@ -11,6 +11,10 @@
 
 declare(strict_types=1);
 
+use Cog\Laravel\Love\Reactant\Models\Reactant;
+use Cog\Laravel\Love\Reacter\Models\Reacter;
+use Cog\Laravel\Love\Reaction\Models\Reaction;
+use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -23,7 +27,7 @@ final class CreateLoveReactionsTable extends Migration
      */
     public function up(): void
     {
-        $this->schema->create('love_reactions', function (Blueprint $table) {
+        $this->schema->create((new Reaction())->getTable(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('reacter_id');
@@ -31,38 +35,20 @@ final class CreateLoveReactionsTable extends Migration
             $table->decimal('rate', 4, 2);
             $table->timestamps();
 
-            $table->index([
-                'reactant_id',
-                'reaction_type_id',
-            ]);
-            $table->index([
-                'reactant_id',
-                'reacter_id',
-                'reaction_type_id',
-            ]);
-            $table->index([
-                'reactant_id',
-                'reacter_id',
-            ]);
-            $table->index([
-                'reacter_id',
-                'reaction_type_id',
-            ]);
-
             $table
                 ->foreign('reactant_id')
                 ->references('id')
-                ->on('love_reactants')
+                ->on((new Reactant())->getTable())
                 ->onDelete('cascade');
             $table
                 ->foreign('reacter_id')
                 ->references('id')
-                ->on('love_reacters')
+                ->on((new Reacter())->getTable())
                 ->onDelete('cascade');
             $table
                 ->foreign('reaction_type_id')
                 ->references('id')
-                ->on('love_reaction_types')
+                ->on((new ReactionType())->getTable())
                 ->onDelete('cascade');
         });
     }
@@ -74,6 +60,6 @@ final class CreateLoveReactionsTable extends Migration
      */
     public function down(): void
     {
-        $this->schema->dropIfExists('love_reactions');
+        $this->schema->dropIfExists((new Reaction())->getTable());
     }
 }

--- a/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
+++ b/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
@@ -11,6 +11,7 @@
 
 declare(strict_types=1);
 
+use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -23,7 +24,7 @@ final class CreateLoveReactantReactionCountersTable extends Migration
      */
     public function up(): void
     {
-        $this->schema->create('love_reactant_reaction_counters', function (Blueprint $table) {
+        $this->schema->create((new ReactionCounter())->getTable(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('reaction_type_id');
@@ -56,6 +57,6 @@ final class CreateLoveReactantReactionCountersTable extends Migration
      */
     public function down(): void
     {
-        $this->schema->dropIfExists('love_reactant_reaction_counters');
+        $this->schema->dropIfExists((new ReactionCounter())->getTable());
     }
 }

--- a/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
+++ b/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
@@ -11,6 +11,7 @@
 
 declare(strict_types=1);
 
+use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -23,7 +24,7 @@ final class CreateLoveReactantReactionTotalsTable extends Migration
      */
     public function up(): void
     {
-        $this->schema->create('love_reactant_reaction_totals', function (Blueprint $table) {
+        $this->schema->create((new ReactionTotal())->getTable(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('reactant_id');
             $table->unsignedBigInteger('count');
@@ -45,6 +46,6 @@ final class CreateLoveReactantReactionTotalsTable extends Migration
      */
     public function down(): void
     {
-        $this->schema->dropIfExists('love_reactant_reaction_totals');
+        $this->schema->dropIfExists((new ReactionTotal())->getTable());
     }
 }

--- a/src/Support/Database/Eloquent/Model.php
+++ b/src/Support/Database/Eloquent/Model.php
@@ -27,4 +27,10 @@ abstract class Model extends IlluminateModel
     {
         return Config::get('love.storage.database.connection');
     }
+
+    public function getTable(): string
+    {
+        return Config::get("love.storage.database.tables.{$this->table}")
+            ?? $this->table;
+    }
 }


### PR DESCRIPTION
Proof of concept https://github.com/cybercog/laravel-love/issues/164#issuecomment-622610209
Resolves #163

Define any custom table name in `config/love.php` file
```php
'storage' => [
    'database' => [
        'connection' => env('DB_CONNECTION', 'mysql'),
        'tables' => [
            'love_reacters' => 'custom_reacters',
            'love_reactants' => 'custom_reactants',
            'love_reaction_types' => 'data.reaction_types',
        ],
    ],
],
```

Table names with `null` value will use values from Model's `$table` class property.

Different schema/database could be defined for cross-schema queries by adding its name with dot on the end before the table name, eg. `data.reaction_types`. More details read in #163