### PR TITLE
Add getters for aggregates job

### DIFF
--- a/src/Reactant/Jobs/DecrementReactionAggregatesJob.php
+++ b/src/Reactant/Jobs/DecrementReactionAggregatesJob.php
@@ -57,4 +57,20 @@ final class DecrementReactionAggregatesJob implements
         (new ReactionTotalService($this->reactant))
             ->removeReaction($this->reaction);
     }
+
+    /**
+     * @return ReactantContract
+     */
+    public function getReactant(): ReactantContract
+    {
+        return $this->reactant;
+    }
+
+    /**
+     * @return ReactionContract
+     */
+    public function getReaction(): ReactionContract
+    {
+        return $this->reaction;
+    }
 }

--- a/src/Reactant/Jobs/IncrementReactionAggregatesJob.php
+++ b/src/Reactant/Jobs/IncrementReactionAggregatesJob.php
@@ -57,4 +57,20 @@ final class IncrementReactionAggregatesJob implements
         (new ReactionTotalService($this->reactant))
             ->addReaction($this->reaction);
     }
+
+    /**
+     * @return ReactantContract
+     */
+    public function getReactant(): ReactantContract
+    {
+        return $this->reactant;
+    }
+
+    /**
+     * @return ReactionContract
+     */
+    public function getReaction(): ReactionContract
+    {
+        return $this->reaction;
+    }
 }


### PR DESCRIPTION
I'm using Laravel Job events to determine when `IncrementReactionAggregatesJob` or `DecrementReactionAggregatesJob` is processed.

<pre>Queue::after(function (JobProcessed $event) {
  dd(unserialize($event->job->payload()['data']['command']));
});</pre>

This PR allows easily accessing the private properties in the job class.