### PR TITLE
Rename imported interfaces aliases suffixes from *Contract to *Interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ## [Unreleased]
 
+## [8.6.1] - 2020-10-04
+
+### Changed
+
+- ([#178]) Rename imported interfaces aliases
+
 ## [8.6.0] - 2020-10-02
 
 ### Added
@@ -450,7 +456,8 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 
 - Initial release
 
-[Unreleased]: https://github.com/cybercog/laravel-love/compare/8.6.0...master
+[Unreleased]: https://github.com/cybercog/laravel-love/compare/8.6.1...master
+[8.6.1]: https://github.com/cybercog/laravel-love/compare/8.6.0...8.6.1
 [8.6.0]: https://github.com/cybercog/laravel-love/compare/8.5.0...8.6.0
 [8.5.0]: https://github.com/cybercog/laravel-love/compare/8.4.0...8.5.0
 [8.4.0]: https://github.com/cybercog/laravel-love/compare/8.3.1...8.4.0
@@ -493,6 +500,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#178]: https://github.com/cybercog/laravel-love/pull/178
 [#177]: https://github.com/cybercog/laravel-love/pull/177
 [#176]: https://github.com/cybercog/laravel-love/pull/176
 [#165]: https://github.com/cybercog/laravel-love/pull/165

--- a/contracts/Reactable/Exceptions/ReactableInvalid.php
+++ b/contracts/Reactable/Exceptions/ReactableInvalid.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Cog\Contracts\Love\Reactable\Exceptions;
 
 use Cog\Contracts\Love\Exceptions\LoveThrowable;
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable;
 use RuntimeException;
 
 final class ReactableInvalid extends RuntimeException implements
@@ -32,7 +32,7 @@ final class ReactableInvalid extends RuntimeException implements
     {
         return new self(sprintf(
             '[%s] must implement `%s` contract.',
-            $type, ReactableContract::class
+            $type, Reactable::class
         ));
     }
 }

--- a/contracts/Reacterable/Exceptions/ReacterableInvalid.php
+++ b/contracts/Reacterable/Exceptions/ReacterableInvalid.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Cog\Contracts\Love\Reacterable\Exceptions;
 
 use Cog\Contracts\Love\Exceptions\LoveThrowable;
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable;
 use RuntimeException;
 
 final class ReacterableInvalid extends RuntimeException implements
@@ -32,7 +32,7 @@ final class ReacterableInvalid extends RuntimeException implements
     {
         return new self(sprintf(
             '[%s] must implement `%s` contract.',
-            $type, ReacterableContract::class
+            $type, Reacterable::class
         ));
     }
 }

--- a/src/Console/Commands/Recount.php
+++ b/src/Console/Commands/Recount.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 namespace Cog\Laravel\Love\Console\Commands;
 
 use Cog\Contracts\Love\Reactable\Exceptions\ReactableInvalid;
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
 use Cog\Laravel\Love\Reactant\Jobs\RebuildReactionAggregatesJob;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Bus\Dispatcher as DispatcherInterface;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -59,7 +59,7 @@ final class Recount extends Command
     }
 
     public function __construct(
-        DispatcherContract $dispatcher
+        DispatcherInterface $dispatcher
     ) {
         parent::__construct();
         $this->dispatcher = $dispatcher;
@@ -130,14 +130,14 @@ final class Recount extends Command
      */
     private function reactableModelFromType(
         string $modelType
-    ): ReactableContract {
+    ): ReactableInterface {
         if (!class_exists($modelType)) {
             $modelType = $this->findModelTypeInMorphMap($modelType);
         }
 
         $model = new $modelType();
 
-        if (!$model instanceof ReactableContract) {
+        if (!$model instanceof ReactableInterface) {
             throw ReactableInvalid::notImplementInterface($modelType);
         }
 

--- a/src/Console/Commands/RegisterReactants.php
+++ b/src/Console/Commands/RegisterReactants.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Cog\Laravel\Love\Console\Commands;
 
 use Cog\Contracts\Love\Reactable\Exceptions\ReactableInvalid;
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -94,14 +94,14 @@ final class RegisterReactants extends Command
      */
     private function reactableModelFromType(
         string $modelType
-    ): ReactableContract {
+    ): ReactableInterface {
         if (!class_exists($modelType)) {
             $modelType = $this->findModelTypeInMorphMap($modelType);
         }
 
         $model = new $modelType();
 
-        if (!$model instanceof ReactableContract) {
+        if (!$model instanceof ReactableInterface) {
             throw ReactableInvalid::notImplementInterface($modelType);
         }
 
@@ -149,7 +149,7 @@ final class RegisterReactants extends Command
      * @return Collection
      */
     private function collectModels(
-        ReactableContract $reactableModel,
+        ReactableInterface $reactableModel,
         array $modelIds
     ): Collection {
         $query = $reactableModel

--- a/src/Console/Commands/RegisterReacters.php
+++ b/src/Console/Commands/RegisterReacters.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Cog\Laravel\Love\Console\Commands;
 
 use Cog\Contracts\Love\Reacterable\Exceptions\ReacterableInvalid;
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -94,14 +94,14 @@ final class RegisterReacters extends Command
      */
     private function reacterableModelFromType(
         string $modelType
-    ): ReacterableContract {
+    ): ReacterableInterface {
         if (!class_exists($modelType)) {
             $modelType = $this->findModelTypeInMorphMap($modelType);
         }
 
         $model = new $modelType();
 
-        if (!$model instanceof ReacterableContract) {
+        if (!$model instanceof ReacterableInterface) {
             throw ReacterableInvalid::notImplementInterface($modelType);
         }
 
@@ -149,7 +149,7 @@ final class RegisterReacters extends Command
      * @return Collection
      */
     private function collectModels(
-        ReacterableContract $reacterableModel,
+        ReacterableInterface $reacterableModel,
         array $modelIds
     ): Collection {
         $query = $reacterableModel

--- a/src/Console/Commands/SetupReactable.php
+++ b/src/Console/Commands/SetupReactable.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Console\Commands;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\Support\Database\AddForeignColumnStub;
 use Cog\Laravel\Love\Support\Database\MigrationCreator;
@@ -170,7 +170,7 @@ final class SetupReactable extends Command
 
     private function isModelInvalid(Model $model): bool
     {
-        return !$model instanceof ReactableContract;
+        return !$model instanceof ReactableInterface;
     }
 
     private function getMigrationsPath(): string

--- a/src/Console/Commands/SetupReacterable.php
+++ b/src/Console/Commands/SetupReacterable.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Console\Commands;
 
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
 use Cog\Laravel\Love\Reacter\Models\Reacter;
 use Cog\Laravel\Love\Support\Database\AddForeignColumnStub;
 use Cog\Laravel\Love\Support\Database\MigrationCreator;
@@ -170,7 +170,7 @@ final class SetupReacterable extends Command
 
     private function isModelInvalid(Model $model): bool
     {
-        return !$model instanceof ReacterableContract;
+        return !$model instanceof ReacterableInterface;
     }
 
     private function getMigrationsPath(): string

--- a/src/Console/Commands/UpgradeV5ToV6.php
+++ b/src/Console/Commands/UpgradeV5ToV6.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Console\Commands;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Illuminate\Console\Command;
@@ -145,7 +145,7 @@ final class UpgradeV5ToV6 extends Command
                 continue;
             }
 
-            if (!in_array(ReacterableContract::class, class_implements($class))) {
+            if (!in_array(ReacterableInterface::class, class_implements($class))) {
                 $this->warn("Class `{$class}` need to implement Reacterable contract.");
                 continue;
             }
@@ -192,7 +192,7 @@ final class UpgradeV5ToV6 extends Command
                 continue;
             }
 
-            if (!in_array(ReactableContract::class, class_implements($class))) {
+            if (!in_array(ReactableInterface::class, class_implements($class))) {
                 $this->warn("Class `{$class}` need to implement Reactable contract.");
                 continue;
             }
@@ -246,7 +246,7 @@ final class UpgradeV5ToV6 extends Command
                 continue;
             }
 
-            /** @var ReactableContract $reactable */
+            /** @var ReactableInterface $reactable */
             $reactable = $class::whereKey($like->likeable_id)->firstOrFail();
 
             $userClass = $this->getUserClass();
@@ -257,7 +257,7 @@ final class UpgradeV5ToV6 extends Command
                 continue;
             }
 
-            /** @var ReacterableContract $reacterable */
+            /** @var ReacterableInterface $reacterable */
             $reacterable = $userClass::whereKey($like->user_id)->firstOrFail();
             $reactionTypeName = $this->reactionTypeNameFromLikeTypeName($like->type_id);
 

--- a/src/Reactable/Models/Traits/Reactable.php
+++ b/src/Reactable/Models/Traits/Reactable.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Cog\Laravel\Love\Reactable\Models\Traits;
 
 use Cog\Contracts\Love\Reactable\Exceptions\AlreadyRegisteredAsLoveReactant;
-use Cog\Contracts\Love\Reactant\Facades\Reactant as ReactantFacadeContract;
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reactant\Facades\Reactant as ReactantFacadeInterface;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
 use Cog\Laravel\Love\Reactable\Observers\ReactableObserver;
 use Cog\Laravel\Love\Reactant\Facades\Reactant as ReactantFacade;
 use Cog\Laravel\Love\Reactant\Models\NullReactant;
@@ -45,12 +45,12 @@ trait Reactable
         return $this->belongsTo(Reactant::class, 'love_reactant_id');
     }
 
-    public function getLoveReactant(): ReactantContract
+    public function getLoveReactant(): ReactantInterface
     {
         return $this->getAttribute('loveReactant') ?? new NullReactant($this);
     }
 
-    public function viaLoveReactant(): ReactantFacadeContract
+    public function viaLoveReactant(): ReactantFacadeInterface
     {
         return new ReactantFacade($this->getLoveReactant());
     }
@@ -82,7 +82,7 @@ trait Reactable
 
     public function scopeWhereReactedBy(
         Builder $query,
-        ReacterableContract $reacterable,
+        ReacterableInterface $reacterable,
         ?string $reactionTypeName = null
     ): Builder {
         return $query->whereHas('loveReactant.reactions', function (Builder $reactionsQuery) use ($reacterable, $reactionTypeName) {
@@ -95,7 +95,7 @@ trait Reactable
 
     public function scopeWhereNotReactedBy(
         Builder $query,
-        ReacterableContract $reacterable,
+        ReacterableInterface $reacterable,
         ?string $reactionTypeName = null
     ): Builder {
         return $query->whereDoesntHave('loveReactant.reactions', function (Builder $reactionsQuery) use ($reacterable, $reactionTypeName) {

--- a/src/Reactable/Observers/ReactableObserver.php
+++ b/src/Reactable/Observers/ReactableObserver.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactable\Observers;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
 
 final class ReactableObserver
 {
     public function created(
-        ReactableContract $reactable
+        ReactableInterface $reactable
     ): void {
         if ($this->shouldRegisterAsReactantOnCreate($reactable)
             && $reactable->isNotRegisteredAsLoveReactant()) {
@@ -27,7 +27,7 @@ final class ReactableObserver
     }
 
     private function shouldRegisterAsReactantOnCreate(
-        ReactableContract $reactable
+        ReactableInterface $reactable
     ): bool {
         return !method_exists($reactable, 'shouldRegisterAsLoveReactantOnCreate')
             || $reactable->shouldRegisterAsLoveReactantOnCreate();

--- a/src/Reactant/Facades/Reactant.php
+++ b/src/Reactant/Facades/Reactant.php
@@ -13,22 +13,22 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\Facades;
 
-use Cog\Contracts\Love\Reactant\Facades\Reactant as ReacterFacadeContract;
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
-use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterContract;
-use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalContract;
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reactant\Facades\Reactant as ReacterFacadeInterface;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
+use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterInterface;
+use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalInterface;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 
 final class Reactant implements
-    ReacterFacadeContract
+    ReacterFacadeInterface
 {
     /**
-     * @var ReactantContract
+     * @var ReactantInterface
      */
     private $reactant;
 
-    public function __construct(ReactantContract $reactant)
+    public function __construct(ReactantInterface $reactant)
     {
         $this->reactant = $reactant;
     }
@@ -51,19 +51,19 @@ final class Reactant implements
 
     public function getReactionCounterOfType(
         string $reactionTypeName
-    ): ReactionCounterContract {
+    ): ReactionCounterInterface {
         return $this->reactant->getReactionCounterOfType(
             ReactionType::fromName($reactionTypeName)
         );
     }
 
-    public function getReactionTotal(): ReactionTotalContract
+    public function getReactionTotal(): ReactionTotalInterface
     {
         return $this->reactant->getReactionTotal();
     }
 
     public function isReactedBy(
-        ?ReacterableContract $reacterable = null,
+        ?ReacterableInterface $reacterable = null,
         ?string $reactionTypeName = null,
         ?float $rate = null
     ): bool {
@@ -81,7 +81,7 @@ final class Reactant implements
     }
 
     public function isNotReactedBy(
-        ?ReacterableContract $reacterable = null,
+        ?ReacterableInterface $reacterable = null,
         ?string $reactionTypeName = null,
         ?float $rate = null
     ): bool {

--- a/src/Reactant/Jobs/DecrementReactionAggregatesJob.php
+++ b/src/Reactant/Jobs/DecrementReactionAggregatesJob.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\Jobs;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
-use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
+use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionInterface;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Services\ReactionCounterService;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Services\ReactionTotalService;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueContract;
+use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueInterface;
 use Illuminate\Foundation\Bus\Dispatchable;
 
 final class DecrementReactionAggregatesJob implements
-    ShouldQueueContract
+    ShouldQueueInterface
 {
     use Dispatchable;
     use Queueable;
@@ -42,8 +42,8 @@ final class DecrementReactionAggregatesJob implements
      * @param \Cog\Contracts\Love\Reaction\Models\Reaction $reaction
      */
     public function __construct(
-        ReactantContract $reactant,
-        ReactionContract $reaction
+        ReactantInterface $reactant,
+        ReactionInterface $reaction
     ) {
         $this->reactant = $reactant;
         $this->reaction = $reaction;
@@ -59,17 +59,17 @@ final class DecrementReactionAggregatesJob implements
     }
 
     /**
-     * @return ReactantContract
+     * @return ReactantInterface
      */
-    public function getReactant(): ReactantContract
+    public function getReactant(): ReactantInterface
     {
         return $this->reactant;
     }
 
     /**
-     * @return ReactionContract
+     * @return ReactionInterface
      */
-    public function getReaction(): ReactionContract
+    public function getReaction(): ReactionInterface
     {
         return $this->reaction;
     }

--- a/src/Reactant/Jobs/IncrementReactionAggregatesJob.php
+++ b/src/Reactant/Jobs/IncrementReactionAggregatesJob.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\Jobs;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
-use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
+use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionInterface;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Services\ReactionCounterService;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Services\ReactionTotalService;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueContract;
+use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueInterface;
 use Illuminate\Foundation\Bus\Dispatchable;
 
 final class IncrementReactionAggregatesJob implements
-    ShouldQueueContract
+    ShouldQueueInterface
 {
     use Dispatchable;
     use Queueable;
@@ -42,8 +42,8 @@ final class IncrementReactionAggregatesJob implements
      * @param \Cog\Contracts\Love\Reaction\Models\Reaction $reaction
      */
     public function __construct(
-        ReactantContract $reactant,
-        ReactionContract $reaction
+        ReactantInterface $reactant,
+        ReactionInterface $reaction
     ) {
         $this->reactant = $reactant;
         $this->reaction = $reaction;
@@ -59,17 +59,17 @@ final class IncrementReactionAggregatesJob implements
     }
 
     /**
-     * @return ReactantContract
+     * @return ReactantInterface
      */
-    public function getReactant(): ReactantContract
+    public function getReactant(): ReactantInterface
     {
         return $this->reactant;
     }
 
     /**
-     * @return ReactionContract
+     * @return ReactionInterface
      */
-    public function getReaction(): ReactionContract
+    public function getReaction(): ReactionInterface
     {
         return $this->reaction;
     }

--- a/src/Reactant/Jobs/RebuildReactionAggregatesJob.php
+++ b/src/Reactant/Jobs/RebuildReactionAggregatesJob.php
@@ -13,20 +13,20 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\Jobs;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
-use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterContract;
-use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalContract;
-use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
+use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterInterface;
+use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalInterface;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Services\ReactionCounterService;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\NullReactionTotal;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueContract;
+use Illuminate\Contracts\Queue\ShouldQueue as ShouldQueueInterface;
 use Illuminate\Foundation\Bus\Dispatchable;
 
 final class RebuildReactionAggregatesJob implements
-    ShouldQueueContract
+    ShouldQueueInterface
 {
     use Dispatchable;
     use Queueable;
@@ -42,8 +42,8 @@ final class RebuildReactionAggregatesJob implements
     private $reactionType;
 
     public function __construct(
-        ReactantContract $reactant,
-        ?ReactionTypeContract $reactionType = null
+        ReactantInterface $reactant,
+        ?ReactionTypeInterface $reactionType = null
     ) {
         $this->reactant = $reactant;
         $this->reactionType = $reactionType;
@@ -93,7 +93,7 @@ final class RebuildReactionAggregatesJob implements
     }
 
     private function findOrCreateReactionTotal(
-    ): ReactionTotalContract {
+    ): ReactionTotalInterface {
         $reactionTotal = $this->reactant->getReactionTotal();
 
         if ($reactionTotal instanceof NullReactionTotal) {
@@ -139,11 +139,11 @@ final class RebuildReactionAggregatesJob implements
     /**
      * Determine if counter should not be rebuilt.
      *
-     * @param ReactionCounterContract $counter
+     * @param ReactionCounterInterface $counter
      * @return bool
      */
     private function shouldNotAffectCounter(
-        ReactionCounterContract $counter
+        ReactionCounterInterface $counter
     ): bool {
         return $this->reactionType !== null
             && $counter->isNotReactionOfType($this->reactionType);

--- a/src/Reactant/Listeners/DecrementAggregates.php
+++ b/src/Reactant/Listeners/DecrementAggregates.php
@@ -15,7 +15,7 @@ namespace Cog\Laravel\Love\Reactant\Listeners;
 
 use Cog\Laravel\Love\Reactant\Jobs\DecrementReactionAggregatesJob;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenRemoved;
-use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Bus\Dispatcher as DispatcherInterface;
 
 final class DecrementAggregates
 {
@@ -24,7 +24,7 @@ final class DecrementAggregates
      */
     private $dispatcher;
 
-    public function __construct(DispatcherContract $dispatcher)
+    public function __construct(DispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
     }

--- a/src/Reactant/Listeners/IncrementAggregates.php
+++ b/src/Reactant/Listeners/IncrementAggregates.php
@@ -15,7 +15,7 @@ namespace Cog\Laravel\Love\Reactant\Listeners;
 
 use Cog\Laravel\Love\Reactant\Jobs\IncrementReactionAggregatesJob;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenAdded;
-use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Bus\Dispatcher as DispatcherInterface;
 
 final class IncrementAggregates
 {
@@ -24,7 +24,7 @@ final class IncrementAggregates
      */
     private $dispatcher;
 
-    public function __construct(DispatcherContract $dispatcher)
+    public function __construct(DispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
     }

--- a/src/Reactant/Models/NullReactant.php
+++ b/src/Reactant/Models/NullReactant.php
@@ -13,28 +13,28 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\Models;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
 use Cog\Contracts\Love\Reactant\Exceptions\ReactantInvalid;
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
-use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterContract;
-use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalContract;
-use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
-use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
+use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterInterface;
+use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalInterface;
+use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterInterface;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\NullReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\NullReactionTotal;
 use Illuminate\Support\Collection;
 use TypeError;
 
 final class NullReactant implements
-    ReactantContract
+    ReactantInterface
 {
     /**
-     * @var ReactableContract
+     * @var ReactableInterface
      */
     private $reactable;
 
     public function __construct(
-        ReactableContract $reactable
+        ReactableInterface $reactable
     ) {
         $this->reactable = $reactable;
     }
@@ -44,7 +44,7 @@ final class NullReactant implements
         throw new TypeError();
     }
 
-    public function getReactable(): ReactableContract
+    public function getReactable(): ReactableInterface
     {
         return $this->reactable;
     }
@@ -60,40 +60,40 @@ final class NullReactant implements
     }
 
     public function getReactionCounterOfType(
-        ReactionTypeContract $reactionType
-    ): ReactionCounterContract {
+        ReactionTypeInterface $reactionType
+    ): ReactionCounterInterface {
         return new NullReactionCounter($this, $reactionType);
     }
 
-    public function getReactionTotal(): ReactionTotalContract
+    public function getReactionTotal(): ReactionTotalInterface
     {
         return new NullReactionTotal($this);
     }
 
     public function isReactedBy(
-        ReacterContract $reacter,
-        ?ReactionTypeContract $reactionType = null,
+        ReacterInterface $reacter,
+        ?ReactionTypeInterface $reactionType = null,
         ?float $rate = null
     ): bool {
         return false;
     }
 
     public function isNotReactedBy(
-        ReacterContract $reacter,
-        ?ReactionTypeContract $reactionType = null,
+        ReacterInterface $reacter,
+        ?ReactionTypeInterface $reactionType = null,
         ?float $rate = null
     ): bool {
         return true;
     }
 
     public function isEqualTo(
-        ReactantContract $that
+        ReactantInterface $that
     ): bool {
         return $that instanceof self;
     }
 
     public function isNotEqualTo(
-        ReactantContract $that
+        ReactantInterface $that
     ): bool {
         return !$this->isEqualTo($that);
     }
@@ -109,7 +109,7 @@ final class NullReactant implements
     }
 
     public function createReactionCounterOfType(
-        ReactionTypeContract $reactionType
+        ReactionTypeInterface $reactionType
     ): void {
         throw ReactantInvalid::notExists();
     }

--- a/src/Reactant/Models/Reactant.php
+++ b/src/Reactant/Models/Reactant.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\Models;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
 use Cog\Contracts\Love\Reactant\Exceptions\NotAssignedToReactable;
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
 use Cog\Contracts\Love\Reactant\ReactionCounter\Exceptions\ReactionCounterDuplicate;
-use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterContract;
+use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterInterface;
 use Cog\Contracts\Love\Reactant\ReactionTotal\Exceptions\ReactionTotalDuplicate;
-use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalContract;
-use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
-use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
-use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
+use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalInterface;
+use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterInterface;
+use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionInterface;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\NullReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\NullReactionTotal;
@@ -34,7 +34,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 final class Reactant extends Model implements
-    ReactantContract
+    ReactantInterface
 {
     protected $table = 'love_reactants';
 
@@ -77,7 +77,7 @@ final class Reactant extends Model implements
         return $this->getAttributeValue('id');
     }
 
-    public function getReactable(): ReactableContract
+    public function getReactable(): ReactableInterface
     {
         $reactable = $this->getAttribute('reactable');
 
@@ -99,8 +99,8 @@ final class Reactant extends Model implements
     }
 
     public function getReactionCounterOfType(
-        ReactionTypeContract $reactionType
-    ): ReactionCounterContract {
+        ReactionTypeInterface $reactionType
+    ): ReactionCounterInterface {
         // TODO: Test query count with eager loaded relation
         // TODO: Test query count without eager loaded relation
         $counter = $this
@@ -115,15 +115,15 @@ final class Reactant extends Model implements
         return $counter;
     }
 
-    public function getReactionTotal(): ReactionTotalContract
+    public function getReactionTotal(): ReactionTotalInterface
     {
         return $this->getAttribute('reactionTotal')
             ?? new NullReactionTotal($this);
     }
 
     public function isReactedBy(
-        ReacterContract $reacter,
-        ?ReactionTypeContract $reactionType = null,
+        ReacterInterface $reacter,
+        ?ReactionTypeInterface $reactionType = null,
         ?float $rate = null
     ): bool {
         if ($reacter->isNull()) {
@@ -134,7 +134,7 @@ final class Reactant extends Model implements
         if ($this->relationLoaded('reactions')) {
             return $this
                 ->getAttribute('reactions')
-                ->contains(function (ReactionContract $reaction) use ($reacter, $reactionType, $rate) {
+                ->contains(function (ReactionInterface $reaction) use ($reacter, $reactionType, $rate) {
                     if ($reaction->isNotByReacter($reacter)) {
                         return false;
                     }
@@ -165,22 +165,22 @@ final class Reactant extends Model implements
     }
 
     public function isNotReactedBy(
-        ReacterContract $reacter,
-        ?ReactionTypeContract $reactionType = null,
+        ReacterInterface $reacter,
+        ?ReactionTypeInterface $reactionType = null,
         ?float $rate = null
     ): bool {
         return !$this->isReactedBy($reacter, $reactionType, $rate);
     }
 
     public function isEqualTo(
-        ReactantContract $that
+        ReactantInterface $that
     ): bool {
         return $that->isNotNull()
             && $this->getId() === $that->getId();
     }
 
     public function isNotEqualTo(
-        ReactantContract $that
+        ReactantInterface $that
     ): bool {
         return !$this->isEqualTo($that);
     }
@@ -196,7 +196,7 @@ final class Reactant extends Model implements
     }
 
     public function createReactionCounterOfType(
-        ReactionTypeContract $reactionType
+        ReactionTypeInterface $reactionType
     ): void {
         if ($this->reactionCounters()->where('reaction_type_id', $reactionType->getId())->exists()) {
             throw ReactionCounterDuplicate::ofTypeForReactant($reactionType, $this);

--- a/src/Reactant/ReactionCounter/Models/NullReactionCounter.php
+++ b/src/Reactant/ReactionCounter/Models/NullReactionCounter.php
@@ -13,50 +13,50 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\ReactionCounter\Models;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
 use Cog\Contracts\Love\Reactant\ReactionCounter\Exceptions\ReactionCounterInvalid;
-use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterContract;
-use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
+use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterInterface;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
 
 final class NullReactionCounter implements
-    ReactionCounterContract
+    ReactionCounterInterface
 {
     /**
-     * @var ReactantContract
+     * @var ReactantInterface
      */
     private $reactant;
 
     /**
-     * @var ReactionTypeContract
+     * @var ReactionTypeInterface
      */
     private $reactionType;
 
     public function __construct(
-        ReactantContract $reactant,
-        ReactionTypeContract $reactionType
+        ReactantInterface $reactant,
+        ReactionTypeInterface $reactionType
     ) {
         $this->reactant = $reactant;
         $this->reactionType = $reactionType;
     }
 
-    public function getReactant(): ReactantContract
+    public function getReactant(): ReactantInterface
     {
         return $this->reactant;
     }
 
-    public function getReactionType(): ReactionTypeContract
+    public function getReactionType(): ReactionTypeInterface
     {
         return $this->reactionType;
     }
 
     public function isReactionOfType(
-        ReactionTypeContract $reactionType
+        ReactionTypeInterface $reactionType
     ): bool {
         return $this->getReactionType()->isEqualTo($reactionType);
     }
 
     public function isNotReactionOfType(
-        ReactionTypeContract $reactionType
+        ReactionTypeInterface $reactionType
     ): bool {
         return !$this->isReactionOfType($reactionType);
     }

--- a/src/Reactant/ReactionCounter/Models/ReactionCounter.php
+++ b/src/Reactant/ReactionCounter/Models/ReactionCounter.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\ReactionCounter\Models;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
-use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterContract;
-use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
+use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterInterface;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Laravel\Love\Support\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 final class ReactionCounter extends Model implements
-    ReactionCounterContract
+    ReactionCounterInterface
 {
     public const COUNT_DEFAULT = 0;
 
@@ -65,24 +65,24 @@ final class ReactionCounter extends Model implements
         return $this->belongsTo(ReactionType::class, 'reaction_type_id');
     }
 
-    public function getReactant(): ReactantContract
+    public function getReactant(): ReactantInterface
     {
         return $this->getAttribute('reactant');
     }
 
-    public function getReactionType(): ReactionTypeContract
+    public function getReactionType(): ReactionTypeInterface
     {
         return $this->getAttribute('reactionType');
     }
 
     public function isReactionOfType(
-        ReactionTypeContract $reactionType
+        ReactionTypeInterface $reactionType
     ): bool {
         return $this->getReactionType()->isEqualTo($reactionType);
     }
 
     public function isNotReactionOfType(
-        ReactionTypeContract $reactionType
+        ReactionTypeInterface $reactionType
     ): bool {
         return !$this->isReactionOfType($reactionType);
     }

--- a/src/Reactant/ReactionCounter/Services/ReactionCounterService.php
+++ b/src/Reactant/ReactionCounter/Services/ReactionCounterService.php
@@ -13,27 +13,27 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\ReactionCounter\Services;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
-use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterContract;
-use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
-use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
+use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterInterface;
+use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionInterface;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\NullReactionCounter;
 
 final class ReactionCounterService
 {
     /**
-     * @var ReactantContract
+     * @var ReactantInterface
      */
     private $reactant;
 
     public function __construct(
-        ReactantContract $reactant
+        ReactantInterface $reactant
     ) {
         $this->reactant = $reactant;
     }
 
     public function addReaction(
-        ReactionContract $reaction
+        ReactionInterface $reaction
     ): void {
         $counter = $this->findOrCreateCounterOfType($reaction->getType());
         $counter->incrementCount(1);
@@ -41,7 +41,7 @@ final class ReactionCounterService
     }
 
     public function removeReaction(
-        ReactionContract $reaction
+        ReactionInterface $reaction
     ): void {
         $counter = $this->findOrCreateCounterOfType($reaction->getType());
 
@@ -54,14 +54,14 @@ final class ReactionCounterService
     }
 
     private function findCounterOfType(
-        ReactionTypeContract $reactionType
-    ): ReactionCounterContract {
+        ReactionTypeInterface $reactionType
+    ): ReactionCounterInterface {
         return $this->reactant->getReactionCounterOfType($reactionType);
     }
 
     private function findOrCreateCounterOfType(
-        ReactionTypeContract $reactionType
-    ): ReactionCounterContract {
+        ReactionTypeInterface $reactionType
+    ): ReactionCounterInterface {
         $counter = $this->findCounterOfType($reactionType);
         if ($counter instanceof NullReactionCounter) {
             $this->reactant->createReactionCounterOfType($reactionType);

--- a/src/Reactant/ReactionTotal/Models/NullReactionTotal.php
+++ b/src/Reactant/ReactionTotal/Models/NullReactionTotal.php
@@ -13,25 +13,25 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\ReactionTotal\Models;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
 use Cog\Contracts\Love\Reactant\ReactionTotal\Exceptions\ReactionTotalInvalid;
-use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalContract;
+use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalInterface;
 
 final class NullReactionTotal implements
-    ReactionTotalContract
+    ReactionTotalInterface
 {
     /**
-     * @var ReactantContract
+     * @var ReactantInterface
      */
     private $reactant;
 
     public function __construct(
-        ReactantContract $reactant
+        ReactantInterface $reactant
     ) {
         $this->reactant = $reactant;
     }
 
-    public function getReactant(): ReactantContract
+    public function getReactant(): ReactantInterface
     {
         return $this->reactant;
     }

--- a/src/Reactant/ReactionTotal/Models/ReactionTotal.php
+++ b/src/Reactant/ReactionTotal/Models/ReactionTotal.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\ReactionTotal\Models;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
-use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
+use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalInterface;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\Support\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 final class ReactionTotal extends Model implements
-    ReactionTotalContract
+    ReactionTotalInterface
 {
     public const COUNT_DEFAULT = 0;
 
@@ -57,7 +57,7 @@ final class ReactionTotal extends Model implements
         return $this->belongsTo(Reactant::class, 'reactant_id');
     }
 
-    public function getReactant(): ReactantContract
+    public function getReactant(): ReactantInterface
     {
         return $this->getAttribute('reactant');
     }

--- a/src/Reactant/ReactionTotal/Services/ReactionTotalService.php
+++ b/src/Reactant/ReactionTotal/Services/ReactionTotalService.php
@@ -13,33 +13,33 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reactant\ReactionTotal\Services;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
-use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalContract;
-use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
+use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalInterface;
+use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionInterface;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\NullReactionTotal;
 
 final class ReactionTotalService
 {
     /**
-     * @var ReactionTotalContract
+     * @var ReactionTotalInterface
      */
     private $reactionTotal;
 
     public function __construct(
-        ReactantContract $reactant
+        ReactantInterface $reactant
     ) {
         $this->reactionTotal = $this->findOrCreateReactionTotalFor($reactant);
     }
 
     public function addReaction(
-        ReactionContract $reaction
+        ReactionInterface $reaction
     ): void {
         $this->reactionTotal->incrementCount(1);
         $this->reactionTotal->incrementWeight($reaction->getWeight());
     }
 
     public function removeReaction(
-        ReactionContract $reaction
+        ReactionInterface $reaction
     ): void {
         if ($this->reactionTotal->getCount() === 0) {
             return;
@@ -50,8 +50,8 @@ final class ReactionTotalService
     }
 
     private function findOrCreateReactionTotalFor(
-        ReactantContract $reactant
-    ): ReactionTotalContract {
+        ReactantInterface $reactant
+    ): ReactionTotalInterface {
         $total = $reactant->getReactionTotal();
 
         if ($total instanceof NullReactionTotal) {

--- a/src/Reacter/Facades/Reacter.php
+++ b/src/Reacter/Facades/Reacter.php
@@ -13,20 +13,20 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reacter\Facades;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
-use Cog\Contracts\Love\Reacter\Facades\Reacter as ReacterFacadeContract;
-use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
+use Cog\Contracts\Love\Reacter\Facades\Reacter as ReacterFacadeInterface;
+use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterInterface;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 
 final class Reacter implements
-    ReacterFacadeContract
+    ReacterFacadeInterface
 {
     /**
-     * @var ReacterContract
+     * @var ReacterInterface
      */
     private $reacter;
 
-    public function __construct(ReacterContract $reacter)
+    public function __construct(ReacterInterface $reacter)
     {
         $this->reacter = $reacter;
     }
@@ -40,7 +40,7 @@ final class Reacter implements
     }
 
     public function reactTo(
-        ReactableContract $reactable,
+        ReactableInterface $reactable,
         string $reactionTypeName,
         ?float $rate = null
     ): void {
@@ -52,7 +52,7 @@ final class Reacter implements
     }
 
     public function unreactTo(
-        ReactableContract $reactable,
+        ReactableInterface $reactable,
         string $reactionTypeName
     ): void {
         $this->reacter->unreactTo(
@@ -62,7 +62,7 @@ final class Reacter implements
     }
 
     public function hasReactedTo(
-        ReactableContract $reactable,
+        ReactableInterface $reactable,
         ?string $reactionTypeName = null,
         ?float $rate = null
     ): bool {
@@ -76,7 +76,7 @@ final class Reacter implements
     }
 
     public function hasNotReactedTo(
-        ReactableContract $reactable,
+        ReactableInterface $reactable,
         ?string $reactionTypeName = null,
         ?float $rate = null
     ): bool {

--- a/src/Reacter/Models/NullReacter.php
+++ b/src/Reacter/Models/NullReacter.php
@@ -13,24 +13,24 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reacter\Models;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
 use Cog\Contracts\Love\Reacter\Exceptions\ReacterInvalid;
-use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
-use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
+use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterInterface;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
 use Illuminate\Support\Collection;
 use TypeError;
 
 final class NullReacter implements
-    ReacterContract
+    ReacterInterface
 {
     /**
-     * @var ReacterableContract
+     * @var ReacterableInterface
      */
     private $reacterable;
 
     public function __construct(
-        ReacterableContract $reacterable
+        ReacterableInterface $reacterable
     ) {
         $this->reacterable = $reacterable;
     }
@@ -40,7 +40,7 @@ final class NullReacter implements
         throw new TypeError();
     }
 
-    public function getReacterable(): ReacterableContract
+    public function getReacterable(): ReacterableInterface
     {
         return $this->reacterable;
     }
@@ -51,44 +51,44 @@ final class NullReacter implements
     }
 
     public function reactTo(
-        ReactantContract $reactant,
-        ReactionTypeContract $reactionType,
+        ReactantInterface $reactant,
+        ReactionTypeInterface $reactionType,
         ?float $rate = null
     ): void {
         throw ReacterInvalid::notExists();
     }
 
     public function unreactTo(
-        ReactantContract $reactant,
-        ReactionTypeContract $reactionType
+        ReactantInterface $reactant,
+        ReactionTypeInterface $reactionType
     ): void {
         throw ReacterInvalid::notExists();
     }
 
     public function hasReactedTo(
-        ReactantContract $reactant,
-        ?ReactionTypeContract $reactionType = null,
+        ReactantInterface $reactant,
+        ?ReactionTypeInterface $reactionType = null,
         ?float $rate = null
     ): bool {
         return false;
     }
 
     public function hasNotReactedTo(
-        ReactantContract $reactant,
-        ?ReactionTypeContract $reactionType = null,
+        ReactantInterface $reactant,
+        ?ReactionTypeInterface $reactionType = null,
         ?float $rate = null
     ): bool {
         return true;
     }
 
     public function isEqualTo(
-        ReacterContract $that
+        ReacterInterface $that
     ): bool {
         return $that instanceof self;
     }
 
     public function isNotEqualTo(
-        ReacterContract $that
+        ReacterInterface $that
     ): bool {
         return !$this->isEqualTo($that);
     }

--- a/src/Reacter/Models/Reacter.php
+++ b/src/Reacter/Models/Reacter.php
@@ -14,21 +14,21 @@ declare(strict_types=1);
 namespace Cog\Laravel\Love\Reacter\Models;
 
 use Cog\Contracts\Love\Reactant\Exceptions\ReactantInvalid;
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
 use Cog\Contracts\Love\Reacter\Exceptions\NotAssignedToReacterable;
-use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterInterface;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
 use Cog\Contracts\Love\Reaction\Exceptions\ReactionAlreadyExists;
 use Cog\Contracts\Love\Reaction\Exceptions\ReactionNotExists;
-use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
-use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
+use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionInterface;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
 use Cog\Laravel\Love\Support\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 final class Reacter extends Model implements
-    ReacterContract
+    ReacterInterface
 {
     protected $table = 'love_reacters';
 
@@ -61,7 +61,7 @@ final class Reacter extends Model implements
         return $this->getAttributeValue('id');
     }
 
-    public function getReacterable(): ReacterableContract
+    public function getReacterable(): ReacterableInterface
     {
         $reacterable = $this->getAttribute('reacterable');
 
@@ -78,8 +78,8 @@ final class Reacter extends Model implements
     }
 
     public function reactTo(
-        ReactantContract $reactant,
-        ReactionTypeContract $reactionType,
+        ReactantInterface $reactant,
+        ReactionTypeInterface $reactionType,
         ?float $rate = null
     ): void {
         if ($reactant->isNull()) {
@@ -105,8 +105,8 @@ final class Reacter extends Model implements
     }
 
     public function unreactTo(
-        ReactantContract $reactant,
-        ReactionTypeContract $reactionType
+        ReactantInterface $reactant,
+        ReactionTypeInterface $reactionType
     ): void {
         if ($reactant->isNull()) {
             throw ReactantInvalid::notExists();
@@ -125,8 +125,8 @@ final class Reacter extends Model implements
     }
 
     public function hasReactedTo(
-        ReactantContract $reactant,
-        ?ReactionTypeContract $reactionType = null,
+        ReactantInterface $reactant,
+        ?ReactionTypeInterface $reactionType = null,
         ?float $rate = null
     ): bool {
         if ($reactant->isNull()) {
@@ -137,22 +137,22 @@ final class Reacter extends Model implements
     }
 
     public function hasNotReactedTo(
-        ReactantContract $reactant,
-        ?ReactionTypeContract $reactionType = null,
+        ReactantInterface $reactant,
+        ?ReactionTypeInterface $reactionType = null,
         ?float $rate = null
     ): bool {
         return $reactant->isNotReactedBy($this, $reactionType, $rate);
     }
 
     public function isEqualTo(
-        ReacterContract $that
+        ReacterInterface $that
     ): bool {
         return $that->isNotNull()
             && $this->getId() === $that->getId();
     }
 
     public function isNotEqualTo(
-        ReacterContract $that
+        ReacterInterface $that
     ): bool {
         return !$this->isEqualTo($that);
     }
@@ -168,8 +168,8 @@ final class Reacter extends Model implements
     }
 
     private function createReaction(
-        ReactantContract $reactant,
-        ReactionTypeContract $reactionType,
+        ReactantInterface $reactant,
+        ReactionTypeInterface $reactionType,
         ?float $rate = null
     ): void {
         $this->reactions()->create([
@@ -185,9 +185,9 @@ final class Reacter extends Model implements
      * @return \Cog\Contracts\Love\Reaction\Models\Reaction|\Illuminate\Database\Eloquent\Model|null
      */
     private function findReaction(
-        ReactantContract $reactant,
-        ReactionTypeContract $reactionType
-    ): ?ReactionContract {
+        ReactantInterface $reactant,
+        ReactionTypeInterface $reactionType
+    ): ?ReactionInterface {
         return $this
             ->reactions()
             ->where('reactant_id', $reactant->getId())

--- a/src/Reacterable/Models/Traits/Reacterable.php
+++ b/src/Reacterable/Models/Traits/Reacterable.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reacterable\Models\Traits;
 
-use Cog\Contracts\Love\Reacter\Facades\Reacter as ReacterFacadeContract;
-use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
+use Cog\Contracts\Love\Reacter\Facades\Reacter as ReacterFacadeInterface;
+use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterInterface;
 use Cog\Contracts\Love\Reacterable\Exceptions\AlreadyRegisteredAsLoveReacter;
 use Cog\Laravel\Love\Reacter\Facades\Reacter as ReacterFacade;
 use Cog\Laravel\Love\Reacter\Models\NullReacter;
@@ -37,12 +37,12 @@ trait Reacterable
         return $this->belongsTo(Reacter::class, 'love_reacter_id');
     }
 
-    public function getLoveReacter(): ReacterContract
+    public function getLoveReacter(): ReacterInterface
     {
         return $this->getAttribute('loveReacter') ?? new NullReacter($this);
     }
 
-    public function viaLoveReacter(): ReacterFacadeContract
+    public function viaLoveReacter(): ReacterFacadeInterface
     {
         return new ReacterFacade($this->getLoveReacter());
     }

--- a/src/Reacterable/Observers/ReacterableObserver.php
+++ b/src/Reacterable/Observers/ReacterableObserver.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reacterable\Observers;
 
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
 
 final class ReacterableObserver
 {
     public function created(
-        ReacterableContract $reacterable
+        ReacterableInterface $reacterable
     ): void {
         if ($this->shouldRegisterAsReacterOnCreate($reacterable)
             && $reacterable->isNotRegisteredAsLoveReacter()) {
@@ -27,7 +27,7 @@ final class ReacterableObserver
     }
 
     private function shouldRegisterAsReacterOnCreate(
-        ReacterableContract $reacterable
+        ReacterableInterface $reacterable
     ): bool {
         return !method_exists($reacterable, 'shouldRegisterAsLoveReacterOnCreate')
             || $reacterable->shouldRegisterAsLoveReacterOnCreate();

--- a/src/Reaction/Events/ReactionHasBeenAdded.php
+++ b/src/Reaction/Events/ReactionHasBeenAdded.php
@@ -13,22 +13,22 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reaction\Events;
 
-use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
+use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionInterface;
 
 final class ReactionHasBeenAdded
 {
     /**
-     * @var ReactionContract
+     * @var ReactionInterface
      */
     private $reaction;
 
     public function __construct(
-        ReactionContract $reaction
+        ReactionInterface $reaction
     ) {
         $this->reaction = $reaction;
     }
 
-    public function getReaction(): ReactionContract
+    public function getReaction(): ReactionInterface
     {
         return $this->reaction;
     }

--- a/src/Reaction/Events/ReactionHasBeenRemoved.php
+++ b/src/Reaction/Events/ReactionHasBeenRemoved.php
@@ -13,22 +13,22 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reaction\Events;
 
-use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
+use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionInterface;
 
 final class ReactionHasBeenRemoved
 {
     /**
-     * @var ReactionContract
+     * @var ReactionInterface
      */
     private $reaction;
 
     public function __construct(
-        ReactionContract $reaction
+        ReactionInterface $reaction
     ) {
         $this->reaction = $reaction;
     }
 
-    public function getReaction(): ReactionContract
+    public function getReaction(): ReactionInterface
     {
         return $this->reaction;
     }

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reaction\Models;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
-use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
+use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterInterface;
 use Cog\Contracts\Love\Reaction\Exceptions\RateInvalid;
 use Cog\Contracts\Love\Reaction\Exceptions\RateOutOfRange;
-use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionContract;
-use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
+use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionInterface;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\Reacter\Models\Reacter;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
@@ -26,7 +26,7 @@ use Cog\Laravel\Love\Support\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 final class Reaction extends Model implements
-    ReactionContract
+    ReactionInterface
 {
     public const RATE_DEFAULT = 1.0;
 
@@ -80,17 +80,17 @@ final class Reaction extends Model implements
         return $this->getAttributeValue('id');
     }
 
-    public function getReactant(): ReactantContract
+    public function getReactant(): ReactantInterface
     {
         return $this->getAttribute('reactant');
     }
 
-    public function getReacter(): ReacterContract
+    public function getReacter(): ReacterInterface
     {
         return $this->getAttribute('reacter');
     }
 
-    public function getType(): ReactionTypeContract
+    public function getType(): ReactionTypeInterface
     {
         return $this->getAttribute('type');
     }
@@ -116,37 +116,37 @@ final class Reaction extends Model implements
     }
 
     public function isOfType(
-        ReactionTypeContract $reactionType
+        ReactionTypeInterface $reactionType
     ): bool {
         return $this->getType()->isEqualTo($reactionType);
     }
 
     public function isNotOfType(
-        ReactionTypeContract $reactionType
+        ReactionTypeInterface $reactionType
     ): bool {
         return $this->getType()->isNotEqualTo($reactionType);
     }
 
     public function isToReactant(
-        ReactantContract $reactant
+        ReactantInterface $reactant
     ): bool {
         return $this->getReactant()->isEqualTo($reactant);
     }
 
     public function isNotToReactant(
-        ReactantContract $reactant
+        ReactantInterface $reactant
     ): bool {
         return !$this->isToReactant($reactant);
     }
 
     public function isByReacter(
-        ReacterContract $reacter
+        ReacterInterface $reacter
     ): bool {
         return $this->getReacter()->isEqualTo($reacter);
     }
 
     public function isNotByReacter(
-        ReacterContract $reacter
+        ReacterInterface $reacter
     ): bool {
         return !$this->isByReacter($reacter);
     }

--- a/src/Reaction/Observers/ReactionObserver.php
+++ b/src/Reaction/Observers/ReactionObserver.php
@@ -16,17 +16,17 @@ namespace Cog\Laravel\Love\Reaction\Observers;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenAdded;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenRemoved;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
-use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherInterface;
 
 final class ReactionObserver
 {
     /**
-     * @var DispatcherContract
+     * @var DispatcherInterface
      */
     private $eventDispatcher;
 
     public function __construct(
-        DispatcherContract $eventDispatcher
+        DispatcherInterface $eventDispatcher
     ) {
         $this->eventDispatcher = $eventDispatcher;
     }

--- a/src/ReactionType/Models/ReactionType.php
+++ b/src/ReactionType/Models/ReactionType.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace Cog\Laravel\Love\ReactionType\Models;
 
 use Cog\Contracts\Love\ReactionType\Exceptions\ReactionTypeInvalid;
-use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
 use Cog\Laravel\Love\Support\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 final class ReactionType extends Model implements
-    ReactionTypeContract
+    ReactionTypeInterface
 {
     public const MASS_DEFAULT = 0;
 
@@ -74,7 +74,7 @@ final class ReactionType extends Model implements
 
     public static function fromName(
         string $name
-    ): ReactionTypeContract {
+    ): ReactionTypeInterface {
         if (isset(self::$nameCache[$name])) {
             return self::$nameCache[$name];
         }
@@ -107,13 +107,13 @@ final class ReactionType extends Model implements
     }
 
     public function isEqualTo(
-        ReactionTypeContract $that
+        ReactionTypeInterface $that
     ): bool {
         return $this->getId() === $that->getId();
     }
 
     public function isNotEqualTo(
-        ReactionTypeContract $that
+        ReactionTypeInterface $that
     ): bool {
         return !$this->isEqualTo($that);
     }

--- a/tests/Stubs/Models/Article.php
+++ b/tests/Stubs/Models/Article.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Stubs\Models;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
 use Cog\Laravel\Love\Reactable\Models\Traits\Reactable;
 use Illuminate\Database\Eloquent\Model;
 
 final class Article extends Model implements
-    ReactableContract
+    ReactableInterface
 {
     use Reactable;
 

--- a/tests/Stubs/Models/ArticleWithoutAutoReactantCreate.php
+++ b/tests/Stubs/Models/ArticleWithoutAutoReactantCreate.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Stubs\Models;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
 use Cog\Laravel\Love\Reactable\Models\Traits\Reactable;
 use Illuminate\Database\Eloquent\Model;
 
 final class ArticleWithoutAutoReactantCreate extends Model implements
-    ReactableContract
+    ReactableInterface
 {
     use Reactable;
 

--- a/tests/Stubs/Models/Bot.php
+++ b/tests/Stubs/Models/Bot.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Stubs\Models;
 
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
 use Cog\Laravel\Love\Reacterable\Models\Traits\Reacterable;
 use Illuminate\Database\Eloquent\Model;
 
 final class Bot extends Model implements
-    ReacterableContract
+    ReacterableInterface
 {
     use Reacterable;
 

--- a/tests/Stubs/Models/Entity.php
+++ b/tests/Stubs/Models/Entity.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Stubs\Models;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
 use Cog\Laravel\Love\Reactable\Models\Traits\Reactable;
 use Illuminate\Database\Eloquent\Model;
 
 final class Entity extends Model implements
-    ReactableContract
+    ReactableInterface
 {
     use Reactable;
 

--- a/tests/Stubs/Models/MorphMappedReactable.php
+++ b/tests/Stubs/Models/MorphMappedReactable.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Stubs\Models;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
 use Cog\Laravel\Love\Reactable\Models\Traits\Reactable;
 use Illuminate\Database\Eloquent\Model;
 
 final class MorphMappedReactable extends Model implements
-    ReactableContract
+    ReactableInterface
 {
     use Reactable;
 

--- a/tests/Stubs/Models/MorphMappedReacterable.php
+++ b/tests/Stubs/Models/MorphMappedReacterable.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Stubs\Models;
 
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
 use Cog\Laravel\Love\Reacterable\Models\Traits\Reacterable;
 use Illuminate\Database\Eloquent\Model;
 
 final class MorphMappedReacterable extends Model implements
-    ReacterableContract
+    ReacterableInterface
 {
     use Reacterable;
 

--- a/tests/Stubs/Models/Person.php
+++ b/tests/Stubs/Models/Person.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Stubs\Models;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
 use Cog\Laravel\Love\Reactable\Models\Traits\Reactable;
 use Cog\Laravel\Love\Reacterable\Models\Traits\Reacterable;
 use Illuminate\Database\Eloquent\Model;
 
 final class Person extends Model implements
-    ReacterableContract,
-    ReactableContract
+    ReacterableInterface,
+    ReactableInterface
 {
     use Reactable;
     use Reacterable;

--- a/tests/Stubs/Models/User.php
+++ b/tests/Stubs/Models/User.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Stubs\Models;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
 use Cog\Laravel\Love\Reactable\Models\Traits\Reactable;
 use Cog\Laravel\Love\Reacterable\Models\Traits\Reacterable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
 final class User extends Authenticatable implements
-    ReacterableContract,
-    ReactableContract
+    ReacterableInterface,
+    ReactableInterface
 {
     use Reactable;
     use Reacterable;

--- a/tests/Stubs/Models/UserWithoutAutoReacterCreate.php
+++ b/tests/Stubs/Models/UserWithoutAutoReacterCreate.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Stubs\Models;
 
-use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableContract;
-use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableContract;
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
+use Cog\Contracts\Love\Reacterable\Models\Reacterable as ReacterableInterface;
 use Cog\Laravel\Love\Reactable\Models\Traits\Reactable;
 use Cog\Laravel\Love\Reacterable\Models\Traits\Reacterable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
 final class UserWithoutAutoReacterCreate extends Authenticatable implements
-    ReacterableContract,
-    ReactableContract
+    ReacterableInterface,
+    ReactableInterface
 {
     use Reactable;
     use Reacterable;

--- a/tests/Unit/Console/Commands/RecountTest.php
+++ b/tests/Unit/Console/Commands/RecountTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Cog\Tests\Laravel\Love\Unit\Console\Commands;
 
 use Cog\Contracts\Love\Reactable\Exceptions\ReactableInvalid;
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
-use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
+use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
 use Cog\Laravel\Love\Reacter\Models\Reacter;
@@ -907,8 +907,8 @@ final class RecountTest extends TestCase
     }
 
     private function reactionsCount(
-        ReactantContract $reactant,
-        ReactionTypeContract $reactionType
+        ReactantInterface $reactant,
+        ReactionTypeInterface $reactionType
     ): int {
         return $reactant
             ->getReactionCounterOfType($reactionType)
@@ -916,8 +916,8 @@ final class RecountTest extends TestCase
     }
 
     private function reactionsWeight(
-        ReactantContract $reactant,
-        ReactionTypeContract $reactionType
+        ReactantInterface $reactant,
+        ReactionTypeInterface $reactionType
     ): float {
         return $reactant
             ->getReactionCounterOfType($reactionType)
@@ -925,7 +925,7 @@ final class RecountTest extends TestCase
     }
 
     private function assertReactantLikesCount(
-        ReactantContract $reactant,
+        ReactantInterface $reactant,
         int $count
     ): void {
         $this->assertSame(
@@ -935,7 +935,7 @@ final class RecountTest extends TestCase
     }
 
     private function assertReactantDislikesCount(
-        ReactantContract $reactant,
+        ReactantInterface $reactant,
         int $count
     ): void {
         $this->assertSame(
@@ -945,7 +945,7 @@ final class RecountTest extends TestCase
     }
 
     private function assertReactantLikesWeight(
-        ReactantContract $reactant,
+        ReactantInterface $reactant,
         float $count
     ): void {
         $this->assertSame(
@@ -955,7 +955,7 @@ final class RecountTest extends TestCase
     }
 
     private function assertReactantDislikesWeight(
-        ReactantContract $reactant,
+        ReactantInterface $reactant,
         float $count
     ): void {
         $this->assertSame(
@@ -965,7 +965,7 @@ final class RecountTest extends TestCase
     }
 
     private function assertReactantTotalCount(
-        ReactantContract $reactant,
+        ReactantInterface $reactant,
         int $count
     ): void {
         $this->assertSame(
@@ -975,7 +975,7 @@ final class RecountTest extends TestCase
     }
 
     private function assertReactantTotalWeight(
-        ReactantContract $reactant,
+        ReactantInterface $reactant,
         float $count
     ): void {
         $this->assertSame(

--- a/tests/Unit/Reactable/Observers/ReactableObserverTest.php
+++ b/tests/Unit/Reactable/Observers/ReactableObserverTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Unit\Reactable\Observers;
 
-use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantContract;
+use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
 use Cog\Laravel\Love\Reactant\Models\NullReactant;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Tests\Laravel\Love\Stubs\Models\Article;
@@ -27,7 +27,7 @@ final class ReactableObserverTest extends TestCase
     {
         $article = factory(Article::class)->create();
 
-        $this->assertInstanceOf(ReactantContract::class, $article->getLoveReactant());
+        $this->assertInstanceOf(ReactantInterface::class, $article->getLoveReactant());
     }
 
     /** @test */

--- a/tests/Unit/Reacterable/Observers/ReacterableObserverTest.php
+++ b/tests/Unit/Reacterable/Observers/ReacterableObserverTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Love\Unit\Reacterable\Observers;
 
-use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterContract;
+use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterInterface;
 use Cog\Laravel\Love\Reacter\Models\NullReacter;
 use Cog\Laravel\Love\Reacter\Models\Reacter;
 use Cog\Tests\Laravel\Love\Stubs\Models\User;
@@ -27,7 +27,7 @@ final class ReacterableObserverTest extends TestCase
     {
         $user = factory(User::class)->create();
 
-        $this->assertInstanceOf(ReacterContract::class, $user->getLoveReacter());
+        $this->assertInstanceOf(ReacterInterface::class, $user->getLoveReacter());
     }
 
     /** @test */


### PR DESCRIPTION
This is not a breaking change because it's only aliases renaming.

Not a Laravel way to name interface classes, usually they are called contracts, but in reality contract has a broader meaning which includes interface.