### PR TITLE
Get relations micro optimization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "illuminate/support": "5.7.*|5.8.*|^6.0|^7.0|^8.0"
     },
     "require-dev": {
+        "laravel/legacy-factories": "^1.1",
         "mockery/mockery": "^1.0",
         "orchestra/database": "~3.7.0|~3.8.0|^4.0|^5.0|^6.0",
         "orchestra/testbench": "~3.7.0|~3.8.0|^4.0|^5.0|^6.0",

--- a/src/Reactable/Models/Traits/Reactable.php
+++ b/src/Reactable/Models/Traits/Reactable.php
@@ -47,7 +47,7 @@ trait Reactable
 
     public function getLoveReactant(): ReactantInterface
     {
-        return $this->getAttribute('loveReactant') ?? new NullReactant($this);
+        return $this->getRelationValue('loveReactant') ?? new NullReactant($this);
     }
 
     public function viaLoveReactant(): ReactantFacadeInterface

--- a/src/Reactant/Models/Reactant.php
+++ b/src/Reactant/Models/Reactant.php
@@ -79,7 +79,7 @@ final class Reactant extends Model implements
 
     public function getReactable(): ReactableInterface
     {
-        $reactable = $this->getAttribute('reactable');
+        $reactable = $this->getRelationValue('reactable');
 
         if ($reactable === null) {
             throw new NotAssignedToReactable();
@@ -90,12 +90,12 @@ final class Reactant extends Model implements
 
     public function getReactions(): iterable
     {
-        return $this->getAttribute('reactions');
+        return $this->getRelationValue('reactions');
     }
 
     public function getReactionCounters(): iterable
     {
-        return $this->getAttribute('reactionCounters');
+        return $this->getRelationValue('reactionCounters');
     }
 
     public function getReactionCounterOfType(
@@ -104,7 +104,7 @@ final class Reactant extends Model implements
         // TODO: Test query count with eager loaded relation
         // TODO: Test query count without eager loaded relation
         $counter = $this
-            ->getAttribute('reactionCounters')
+            ->getRelationValue('reactionCounters')
             ->where('reaction_type_id', $reactionType->getId())
             ->first();
 
@@ -117,7 +117,7 @@ final class Reactant extends Model implements
 
     public function getReactionTotal(): ReactionTotalInterface
     {
-        return $this->getAttribute('reactionTotal')
+        return $this->getRelationValue('reactionTotal')
             ?? new NullReactionTotal($this);
     }
 
@@ -133,7 +133,7 @@ final class Reactant extends Model implements
         // TODO: Test if relation was loaded partially
         if ($this->relationLoaded('reactions')) {
             return $this
-                ->getAttribute('reactions')
+                ->getRelationValue('reactions')
                 ->contains(function (ReactionInterface $reaction) use ($reacter, $reactionType, $rate) {
                     if ($reaction->isNotByReacter($reacter)) {
                         return false;

--- a/src/Reactant/ReactionCounter/Models/ReactionCounter.php
+++ b/src/Reactant/ReactionCounter/Models/ReactionCounter.php
@@ -67,12 +67,12 @@ final class ReactionCounter extends Model implements
 
     public function getReactant(): ReactantInterface
     {
-        return $this->getAttribute('reactant');
+        return $this->getRelationValue('reactant');
     }
 
     public function getReactionType(): ReactionTypeInterface
     {
-        return $this->getAttribute('reactionType');
+        return $this->getRelationValue('reactionType');
     }
 
     public function isReactionOfType(

--- a/src/Reactant/ReactionTotal/Models/ReactionTotal.php
+++ b/src/Reactant/ReactionTotal/Models/ReactionTotal.php
@@ -59,7 +59,7 @@ final class ReactionTotal extends Model implements
 
     public function getReactant(): ReactantInterface
     {
-        return $this->getAttribute('reactant');
+        return $this->getRelationValue('reactant');
     }
 
     public function getCount(): int

--- a/src/Reacter/Models/Reacter.php
+++ b/src/Reacter/Models/Reacter.php
@@ -63,7 +63,7 @@ final class Reacter extends Model implements
 
     public function getReacterable(): ReacterableInterface
     {
-        $reacterable = $this->getAttribute('reacterable');
+        $reacterable = $this->getRelationValue('reacterable');
 
         if ($reacterable === null) {
             throw new NotAssignedToReacterable();
@@ -74,7 +74,7 @@ final class Reacter extends Model implements
 
     public function getReactions(): iterable
     {
-        return $this->getAttribute('reactions');
+        return $this->getRelationValue('reactions');
     }
 
     public function reactTo(

--- a/src/Reacterable/Models/Traits/Reacterable.php
+++ b/src/Reacterable/Models/Traits/Reacterable.php
@@ -39,7 +39,7 @@ trait Reacterable
 
     public function getLoveReacter(): ReacterInterface
     {
-        return $this->getAttribute('loveReacter') ?? new NullReacter($this);
+        return $this->getRelationValue('loveReacter') ?? new NullReacter($this);
     }
 
     public function viaLoveReacter(): ReacterFacadeInterface

--- a/src/Reaction/Models/Reaction.php
+++ b/src/Reaction/Models/Reaction.php
@@ -82,17 +82,17 @@ final class Reaction extends Model implements
 
     public function getReactant(): ReactantInterface
     {
-        return $this->getAttribute('reactant');
+        return $this->getRelationValue('reactant');
     }
 
     public function getReacter(): ReacterInterface
     {
-        return $this->getAttribute('reacter');
+        return $this->getRelationValue('reacter');
     }
 
     public function getType(): ReactionTypeInterface
     {
-        return $this->getAttribute('type');
+        return $this->getRelationValue('type');
     }
 
     public function getRate(): float


### PR DESCRIPTION
This PR replaces all `getAttribute` calls to `getRelationValue`. It is safe because all classes are final and only relations are getted via the `getAttribute`. I'm sure that skipping 3 conditionals will gain not much performance improvement, but I like more explicit `getRelationValue` method naming.
```php
public function getAttribute($key)
{
    if (! $key) {
        return;
    }

    // If the attribute exists in the attribute array or has a "get" mutator we will
    // get the attribute's value. Otherwise, we will proceed as if the developers
    // are asking for a relationship's value. This covers both types of values.
    if (array_key_exists($key, $this->attributes) ||
        array_key_exists($key, $this->casts) ||
        $this->hasGetMutator($key) ||
        $this->isClassCastable($key)) {
        return $this->getAttributeValue($key);
    }

    // Here we will determine if the model base class itself contains this given key
    // since we don't want to treat any of those methods as relationships because
    // they are all intended as helper methods and none of these are relations.
    if (method_exists(self::class, $key)) {
        return;
    }

    return $this->getRelationValue($key);
}
```