### PR TITLE
Add query scopes to Reacterable trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,16 @@ All notable changes to `laravel-love` will be documented in this file.
 ### Added
 
 - ([#216]) Added Docker Compose to quick development build
+- ([#188]) Added `scopeWhereReactedTo` model scope to `Reacterable` trait
+- ([#188]) Added `scopeWhereNotReactedTo` model scope to `Reacterable` trait
 
 ### Changed
 
+- ([#222]) Removed DI usage from Console commands constructors
 - ([#215]) Migrated to console AsCommand attribute
 - ([#215]) Package generating anonymous class migrations now
 - ([#217]) Switched to native typed class properties
 - ([#218]) Switched to Symfony Console exit code constants
-- ([#222]) Removed DI usage from Console commands constructors
 
 ### Removed
 
@@ -569,6 +571,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [#206]: https://github.com/cybercog/laravel-love/pull/206
 [#197]: https://github.com/cybercog/laravel-love/pull/197
 [#196]: https://github.com/cybercog/laravel-love/pull/196
+[#188]: https://github.com/cybercog/laravel-love/pull/188
 [#187]: https://github.com/cybercog/laravel-love/pull/187
 [#186]: https://github.com/cybercog/laravel-love/pull/186
 [#185]: https://github.com/cybercog/laravel-love/pull/185

--- a/src/Reacterable/Models/Traits/Reacterable.php
+++ b/src/Reacterable/Models/Traits/Reacterable.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\Laravel\Love\Reacterable\Models\Traits;
 
+use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
 use Cog\Contracts\Love\Reacter\Facades\Reacter as ReacterFacadeInterface;
 use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterInterface;
 use Cog\Contracts\Love\Reacterable\Exceptions\AlreadyRegisteredAsLoveReacter;
@@ -20,6 +21,8 @@ use Cog\Laravel\Love\Reacter\Facades\Reacter as ReacterFacade;
 use Cog\Laravel\Love\Reacter\Models\NullReacter;
 use Cog\Laravel\Love\Reacter\Models\Reacter;
 use Cog\Laravel\Love\Reacterable\Observers\ReacterableObserver;
+use Cog\Laravel\Love\ReactionType\Models\ReactionType;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -70,5 +73,37 @@ trait Reacterable
 
         $this->setAttribute('love_reacter_id', $reacter->getId());
         $this->save();
+    }
+
+    public function scopeWhereReactedTo(
+        Builder $query,
+        ReactableInterface $reactable,
+        ?string $reactionTypeName = null,
+    ): Builder {
+        return $query->whereHas(
+            'loveReacter.reactions',
+            function (Builder $reactionsQuery) use ($reactable, $reactionTypeName) {
+                $reactionsQuery->where('reactant_id', $reactable->getLoveReactant()->getId());
+                if ($reactionTypeName !== null) {
+                    $reactionsQuery->where('reaction_type_id', ReactionType::fromName($reactionTypeName)->getId());
+                }
+            }
+        );
+    }
+
+    public function scopeWhereNotReactedTo(
+        Builder $query,
+        ReactableInterface $reactable,
+        ?string $reactionTypeName = null,
+    ): Builder {
+        return $query->whereDoesntHave(
+            'loveReacter.reactions',
+            function (Builder $reactionsQuery) use ($reactable, $reactionTypeName) {
+                $reactionsQuery->where('reactant_id', $reactable->getLoveReactant()->getId());
+                if ($reactionTypeName !== null) {
+                    $reactionsQuery->where('reaction_type_id', ReactionType::fromName($reactionTypeName)->getId());
+                }
+            }
+        );
     }
 }

--- a/tests/Unit/Reacterable/Models/Traits/ReacterableTest.php
+++ b/tests/Unit/Reacterable/Models/Traits/ReacterableTest.php
@@ -14,9 +14,13 @@ declare(strict_types=1);
 namespace Cog\Tests\Laravel\Love\Unit\Reacterable\Models\Traits;
 
 use Cog\Contracts\Love\Reacterable\Exceptions\AlreadyRegisteredAsLoveReacter;
+use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\Reacter\Facades\Reacter as ReacterFacade;
 use Cog\Laravel\Love\Reacter\Models\NullReacter;
 use Cog\Laravel\Love\Reacter\Models\Reacter;
+use Cog\Laravel\Love\Reaction\Models\Reaction;
+use Cog\Laravel\Love\ReactionType\Models\ReactionType;
+use Cog\Tests\Laravel\Love\Stubs\Models\Article;
 use Cog\Tests\Laravel\Love\Stubs\Models\Bot;
 use Cog\Tests\Laravel\Love\Stubs\Models\User;
 use Cog\Tests\Laravel\Love\TestCase;
@@ -165,5 +169,241 @@ final class ReacterableTest extends TestCase
         $user = factory(User::class)->create();
 
         $user->registerAsLoveReacter();
+    }
+
+    /** @test */
+    public function it_can_scope_reacted_to_reactable(): void
+    {
+        factory(Reacter::class)->create(); // Needed to has not same ids with Reacter
+        $reactionType = factory(ReactionType::class)->create();
+        $reacterable1 = factory(User::class)->create();
+        $reacterable2 = factory(User::class)->create();
+        $reacterable3 = factory(User::class)->create();
+        $reactable1 = factory(Article::class)->create();
+        $reactable2 = factory(Article::class)->create();
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactable1->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable1->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactable1->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable2->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactable1->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable3->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactable2->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable3->getLoveReacter()->getId(),
+        ]);
+
+        $reactedToReactable1 = User::query()
+            ->whereReactedTo($reactable1)
+            ->get();
+        $reactedToReactable2 = User::query()
+            ->whereReactedTo($reactable2)
+            ->get();
+
+        $this->assertSame([
+            $reacterable1->getKey(),
+            $reacterable2->getKey(),
+            $reacterable3->getKey(),
+        ], $reactedToReactable1->pluck('id')->toArray());
+        $this->assertSame([
+            $reacterable3->getKey(),
+        ], $reactedToReactable2->pluck('id')->toArray());
+    }
+
+    /** @test */
+    public function it_can_scope_reacted_to_reactable_and_reaction_type(): void
+    {
+        factory(Reacter::class)->create(); // Needed to has not same ids with Reacter
+        $reactionType1 = factory(ReactionType::class)->create();
+        $reactionType2 = factory(ReactionType::class)->create();
+        $reacterable1 = factory(User::class)->create();
+        $reacterable2 = factory(User::class)->create();
+        $reacterable3 = factory(User::class)->create();
+        $reactable1 = factory(Article::class)->create();
+        $reactable2 = factory(Article::class)->create();
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType1->getId(),
+            'reactant_id' => $reactable1->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable1->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType2->getId(),
+            'reactant_id' => $reactable1->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable2->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType2->getId(),
+            'reactant_id' => $reactable2->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable1->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType1->getId(),
+            'reactant_id' => $reactable2->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable2->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType1->getId(),
+            'reactant_id' => $reactable1->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable3->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType1->getId(),
+            'reactant_id' => $reactable2->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable3->getLoveReacter()->getId(),
+        ]);
+
+        $reactedToReactable1WithReactionType1 = User::query()
+            ->whereReactedTo($reactable1, $reactionType1->getName())
+            ->get();
+        $reactedToReactable1WithReactionType2 = User::query()
+            ->whereReactedTo($reactable1, $reactionType2->getName())
+            ->get();
+        $reactedToReactable2WithReactionType1 = User::query()
+            ->whereReactedTo($reactable2, $reactionType1->getName())
+            ->get();
+        $reactedToReactable2WithReactionType2 = User::query()
+            ->whereReactedTo($reactable2, $reactionType2->getName())
+            ->get();
+
+        $this->assertSame([
+            $reacterable1->getKey(),
+            $reacterable3->getKey(),
+        ], $reactedToReactable1WithReactionType1->pluck('id')->toArray());
+        $this->assertSame([
+            $reacterable2->getKey(),
+        ], $reactedToReactable1WithReactionType2->pluck('id')->toArray());
+        $this->assertSame([
+            $reacterable2->getKey(),
+            $reacterable3->getKey(),
+        ], $reactedToReactable2WithReactionType1->pluck('id')->toArray());
+        $this->assertSame([
+            $reacterable1->getKey(),
+        ], $reactedToReactable2WithReactionType2->pluck('id')->toArray());
+    }
+
+    /** @test */
+    public function it_can_scope_not_reacted_to_reactable(): void
+    {
+        factory(Reactant::class)->create(); // Needed to has not same ids with Reactant
+        $reactionType = factory(ReactionType::class)->create();
+        $reacterable1 = factory(User::class)->create();
+        $reacterable2 = factory(User::class)->create();
+        $reacterable3 = factory(User::class)->create();
+        $reactable1 = factory(Article::class)->create();
+        $reactable2 = factory(Article::class)->create();
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactable1->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable1->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactable2->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable2->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactable1->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable3->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactable2->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable3->getLoveReacter()->getId(),
+        ]);
+
+        $reactedToReactable1 = User::query()
+            ->whereNotReactedTo($reactable1)
+            ->get();
+        $reactedToReactable2 = User::query()
+            ->whereNotReactedTo($reactable2)
+            ->get();
+
+        $this->assertSame([
+            $reactable2->getKey(),
+        ], $reactedToReactable1->pluck('id')->toArray());
+        $this->assertSame([
+            $reactable1->getKey(),
+        ], $reactedToReactable2->pluck('id')->toArray());
+    }
+
+    /** @test */
+    public function it_can_scope_not_reacted_to_reactable_and_reaction_type(): void
+    {
+        factory(Reactant::class)->create(); // Needed to has not same ids with Reactant
+        $reactionType1 = factory(ReactionType::class)->create();
+        $reactionType2 = factory(ReactionType::class)->create();
+        $reacterable1 = factory(User::class)->create();
+        $reacterable2 = factory(User::class)->create();
+        $reacterable3 = factory(User::class)->create();
+        $reactable1 = factory(Article::class)->create();
+        $reactable2 = factory(Article::class)->create();
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType1->getId(),
+            'reactant_id' => $reactable1->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable1->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType2->getId(),
+            'reactant_id' => $reactable1->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable2->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType2->getId(),
+            'reactant_id' => $reactable2->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable1->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType1->getId(),
+            'reactant_id' => $reactable2->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable2->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType1->getId(),
+            'reactant_id' => $reactable1->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable3->getLoveReacter()->getId(),
+        ]);
+        factory(Reaction::class)->create([
+            'reaction_type_id' => $reactionType1->getId(),
+            'reactant_id' => $reactable2->getLoveReactant()->getId(),
+            'reacter_id' => $reacterable3->getLoveReacter()->getId(),
+        ]);
+
+        $reactedToReactable1WithReactionType1 = User::query()
+            ->whereNotReactedTo($reactable1, $reactionType1->getName())
+            ->get();
+        $reactedToReactable1WithReactionType2 = User::query()
+            ->whereNotReactedTo($reactable1, $reactionType2->getName())
+            ->get();
+        $reactedToReactable2WithReactionType1 = User::query()
+            ->whereNotReactedTo($reactable2, $reactionType1->getName())
+            ->get();
+        $reactedToReactable2WithReactionType2 = User::query()
+            ->whereNotReactedTo($reactable2, $reactionType2->getName())
+            ->get();
+
+        $this->assertSame([
+            $reacterable2->getKey(),
+        ], $reactedToReactable1WithReactionType1->pluck('id')->toArray());
+        $this->assertSame([
+            $reacterable1->getKey(),
+            $reacterable3->getKey(),
+        ], $reactedToReactable1WithReactionType2->pluck('id')->toArray());
+        $this->assertSame([
+            $reacterable1->getKey(),
+        ], $reactedToReactable2WithReactionType1->pluck('id')->toArray());
+        $this->assertSame([
+            $reacterable2->getKey(),
+            $reacterable3->getKey(),
+        ], $reactedToReactable2WithReactionType2->pluck('id')->toArray());
     }
 }


### PR DESCRIPTION
This MR adds `whereReactedTo` & `whereNotReactedTo` query scopes to Reacterable trait to find all Reacterable models who reacted to the Reactable model. This concept was born after discussion with @vesper8 in #181

#### Find users who reacted with any type of reaction to the article

```php
$article = Article::whereKey(1)->firstOrFail();

$usersReactedToArticle = User::whereReactedTo($article);
```

#### Find users who reacted with one concerete type of reaction to the article

```php
$article = Article::whereKey(1)->firstOrFail();
$likeReactionType = ReactionType::fromName('Like');

$usersLikedTheArticle = User::whereReactedTo($article, $likeReactionType);
```

This MR doesn't have tests yet and I'm not sure if we should add it to the minor release.