### PR TITLE
Fix CVE-2021-21263 & GHSA-x7p5-p2c9-phvg vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#196]) Fixed CVE-2021-21263 vulnerability
 - ([#196]) Fixed GHSA-x7p5-p2c9-phvg vulnerability
 
-- https://github.com/advisories/GHSA-x7p5-p2c9-phvg
-
 ## [8.7.1] - 2020-12-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ## [Unreleased]
 
+## Removed
+
+- ([#196]) Dropped Laravel 5.7 support
+- ([#196]) Dropped Laravel 5.8 support
+
+## Fixed
+
+- ([#196]) Fixed CVE-2021-21263 vulnerability
+- ([#196]) Fixed GHSA-x7p5-p2c9-phvg vulnerability
+
+- https://github.com/advisories/GHSA-x7p5-p2c9-phvg
+
 ## [8.7.1] - 2020-12-06
 
 ### Fixed
@@ -515,6 +527,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#196]: https://github.com/cybercog/laravel-love/pull/196
 [#187]: https://github.com/cybercog/laravel-love/pull/187
 [#186]: https://github.com/cybercog/laravel-love/pull/186
 [#185]: https://github.com/cybercog/laravel-love/pull/185

--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,8 @@
     },
     "require": {
         "php": "^7.1.3|^8.0",
-        "illuminate/database": "5.7.*|5.8.*|^6.0|^7.0|^8.0",
-        "illuminate/support": "5.7.*|5.8.*|^6.0|^7.0|^8.0"
+        "illuminate/database": "^6.20.14|^7.30.4|^8.24",
+        "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
This PR fixes:
- [CVE-2021-21263](https://github.com/advisories/GHSA-3p32-j457-pg5x)
- [GHSA-x7p5-p2c9-phvg](https://github.com/advisories/GHSA-x7p5-p2c9-phvg)