### PR TITLE
Drop PHP 7.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ## [Unreleased]
 
+## [8.8.1] - 2021-04-03
+
+### Removed
+
+- ([#197]) Dropped PHP 7.1 support
+
 ## [8.8.0] - 2021-04-03
 
 ### Removed
@@ -481,7 +487,8 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 
 - Initial release
 
-[Unreleased]: https://github.com/cybercog/laravel-love/compare/8.8.0...master
+[Unreleased]: https://github.com/cybercog/laravel-love/compare/8.8.1...master
+[8.8.1]: https://github.com/cybercog/laravel-love/compare/8.8.0...8.8.1
 [8.8.0]: https://github.com/cybercog/laravel-love/compare/8.7.1...8.8.0
 [8.7.1]: https://github.com/cybercog/laravel-love/compare/8.7.0...8.7.1
 [8.7.0]: https://github.com/cybercog/laravel-love/compare/8.6.1...8.7.0
@@ -528,6 +535,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#197]: https://github.com/cybercog/laravel-love/pull/197
 [#196]: https://github.com/cybercog/laravel-love/pull/196
 [#187]: https://github.com/cybercog/laravel-love/pull/187
 [#186]: https://github.com/cybercog/laravel-love/pull/186

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "docs": "https://laravel-love.readme.io"
     },
     "require": {
-        "php": "^7.1.3|^8.0",
+        "php": "^7.2.5|^8.0",
         "illuminate/database": "^6.20.14|^7.30.4|^8.24",
         "illuminate/support": "^6.0|^7.0|^8.0"
     },


### PR DESCRIPTION
Followup #196 

Laravel 6.0 requires PHP >= 7.2.5