### PR TITLE
Make love_reactant_id & love_reacter_id columns nullable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to `laravel-love` will be documented in this file.
 
 ### Changed
 
+- ([#231]) Console command `love:setup-reactable` generates migration with nullable column `love_reactant_id` by default
+- ([#231]) Console command `love:setup-reactable` option `--nullable` replaced with `--not-nullable`
+- ([#231]) Console command `love:setup-reacterable` generates migration with nullable column `love_reacter_id` by default
+- ([#231]) Console command `love:setup-reacterable` option `--nullable` replaced with `--not-nullable`
 - ([#222]) Removed DI usage from console commands constructors
 - ([#215]) Migrated to console `AsCommand` attribute
 - ([#215]) Package generating anonymous class migrations now
@@ -563,6 +567,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#231]: https://github.com/cybercog/laravel-love/pull/231
 [#222]: https://github.com/cybercog/laravel-love/pull/222
 [#218]: https://github.com/cybercog/laravel-love/pull/218
 [#217]: https://github.com/cybercog/laravel-love/pull/217

--- a/src/Console/Commands/SetupReactable.php
+++ b/src/Console/Commands/SetupReactable.php
@@ -48,7 +48,7 @@ final class SetupReactable extends Command
         $model = $this->resolveModel();
         $model = $this->sanitizeName($model);
         $foreignColumn = 'love_reactant_id';
-        $isForeignColumnNullable = boolval($this->option('nullable'));
+        $isForeignColumnNullable = boolval($this->option('not-nullable')) === false;
 
         if (!class_exists($model)) {
             $this->error(
@@ -140,9 +140,9 @@ final class SetupReactable extends Command
                 description: 'The name of the reactable model',
             ),
             new InputOption(
-                name: 'nullable',
+                name: 'not-nullable',
                 mode: InputOption::VALUE_NONE,
-                description: 'Indicate if foreign column allows null values',
+                description: 'Indicate if foreign column does not allow null values',
             ),
         ];
     }

--- a/src/Console/Commands/SetupReacterable.php
+++ b/src/Console/Commands/SetupReacterable.php
@@ -48,7 +48,7 @@ final class SetupReacterable extends Command
         $model = $this->resolveModel();
         $model = $this->sanitizeName($model);
         $foreignColumn = 'love_reacter_id';
-        $isForeignColumnNullable = boolval($this->option('nullable'));
+        $isForeignColumnNullable = boolval($this->option('not-nullable')) === false;
 
         if (!class_exists($model)) {
             $this->error(
@@ -140,9 +140,9 @@ final class SetupReacterable extends Command
                 description: 'The name of the reacterable model',
             ),
             new InputOption(
-                name: 'nullable',
+                name: 'not-nullable',
                 mode: InputOption::VALUE_NONE,
-                description: 'Indicate if foreign column allows null values',
+                description: 'Indicate if foreign column does not allow null values',
             ),
         ];
     }

--- a/src/Support/Database/Stubs/AddForeignColumn.stub
+++ b/src/Support/Database/Stubs/AddForeignColumn.stub
@@ -20,7 +20,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('DummyTable', function (Blueprint $table) {
-            $table->unsignedBigInteger('DummyForeignColumn');
+            $table->foreignId('DummyForeignColumn');
 
             $table
                 ->foreign('DummyForeignColumn')

--- a/src/Support/Database/Stubs/AddForeignNullableColumn.stub
+++ b/src/Support/Database/Stubs/AddForeignNullableColumn.stub
@@ -20,7 +20,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('DummyTable', function (Blueprint $table) {
-            $table->unsignedBigInteger('DummyForeignColumn')->nullable();
+            $table->foreignId('DummyForeignColumn')->nullable();
 
             $table
                 ->foreign('DummyForeignColumn')

--- a/tests/Unit/Console/Commands/SetupReactableTest.php
+++ b/tests/Unit/Console/Commands/SetupReactableTest.php
@@ -51,11 +51,11 @@ final class SetupReactableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_create_migration_for_reactable_model_with_nullable_column(): void
+    public function it_can_create_migration_for_reactable_model_with_not_nullable_column(): void
     {
         $status = $this->artisan('love:setup-reactable', [
             '--model' => Person::class,
-            '--nullable' => true,
+            '--not-nullable' => true,
         ]);
 
         $this->assertSame(0, $status);

--- a/tests/Unit/Console/Commands/SetupReacterableTest.php
+++ b/tests/Unit/Console/Commands/SetupReacterableTest.php
@@ -51,11 +51,11 @@ final class SetupReacterableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_create_migration_for_reacterable_model_with_nullable_column(): void
+    public function it_can_create_migration_for_reacterable_model_with_not_nullable_column(): void
     {
         $status = $this->artisan('love:setup-reacterable', [
             '--model' => Person::class,
-            '--nullable' => true,
+            '--not-nullable' => true,
         ]);
 
         $this->assertSame(0, $status);


### PR DESCRIPTION
- Resolves #140 
- Console command `love:setup-reactable` generates migration with nullable column `love_reactant_id` by default
- Console command `love:setup-reactable` option `--nullable` replaced with `--not-nullable`
- Console command `love:setup-reacterable` generates migration with nullable column `love_reacter_id` by default
- Console command `love:setup-reacterable` option `--nullable` replaced with `--not-nullable`