### PR TITLE
Console command love:recount use default queue connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#231]) Console command `love:setup-reactable` option `--nullable` replaced with `--not-nullable`
 - ([#231]) Console command `love:setup-reacterable` generates migration with nullable column `love_reacter_id` by default
 - ([#231]) Console command `love:setup-reacterable` option `--nullable` replaced with `--not-nullable`
-- Console command `love:recount` use default queue connection if `--queue-connection` option is not defined
+- ([#233]) Console command `love:recount` use default queue connection if `--queue-connection` option is not defined
 - ([#222]) Removed DI usage from console commands constructors
 - ([#215]) Migrated to console `AsCommand` attribute
 - ([#215]) Package generating anonymous class migrations now
@@ -568,6 +568,7 @@ Follow [upgrade instructions](UPGRADING.md#from-v5-to-v6) to migrate database to
 [1.1.1]: https://github.com/cybercog/laravel-love/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/cybercog/laravel-love/compare/1.0.0...1.1.0
 
+[#233]: https://github.com/cybercog/laravel-love/pull/233
 [#231]: https://github.com/cybercog/laravel-love/pull/231
 [#222]: https://github.com/cybercog/laravel-love/pull/222
 [#218]: https://github.com/cybercog/laravel-love/pull/218

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to `laravel-love` will be documented in this file.
 - ([#231]) Console command `love:setup-reactable` option `--nullable` replaced with `--not-nullable`
 - ([#231]) Console command `love:setup-reacterable` generates migration with nullable column `love_reacter_id` by default
 - ([#231]) Console command `love:setup-reacterable` option `--nullable` replaced with `--not-nullable`
+- Console command `love:recount` use default queue connection if `--queue-connection` option is not defined
 - ([#222]) Removed DI usage from console commands constructors
 - ([#215]) Migrated to console `AsCommand` attribute
 - ([#215]) Package generating anonymous class migrations now

--- a/src/Console/Commands/Recount.php
+++ b/src/Console/Commands/Recount.php
@@ -20,6 +20,7 @@ use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherInterface;
+use Illuminate\Contracts\Config\Repository as AppConfigRepositoryInterface;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
@@ -62,6 +63,7 @@ final class Recount extends Command
      */
     public function handle(
         DispatcherInterface $dispatcher,
+        AppConfigRepositoryInterface $appConfigRepository,
     ): int {
         $this->dispatcher = $dispatcher;
 
@@ -75,7 +77,7 @@ final class Recount extends Command
 
         $queueConnectionName = $this->option('queue-connection');
         if ($queueConnectionName === null || $queueConnectionName === '') {
-            $queueConnectionName = 'sync';
+            $queueConnectionName = $appConfigRepository->get('queue.default');
         }
 
         $reactants = $this->collectReactants($reactableType);

--- a/src/Console/Commands/Recount.php
+++ b/src/Console/Commands/Recount.php
@@ -82,7 +82,10 @@ final class Recount extends Command
 
         $reactants = $this->collectReactants($reactableType);
 
-        $this->warnProcessingStartedOn($queueConnectionName);
+        $this->warn(
+            "Rebuilding reaction aggregates using `$queueConnectionName` queue connection."
+        );
+
         $this->getOutput()->progressStart($reactants->count());
         foreach ($reactants as $reactant) {
             $this->dispatcher->dispatch(
@@ -167,23 +170,5 @@ final class Recount extends Command
         }
 
         return $reactantsQuery->get();
-    }
-
-    /**
-     * Write warning output that processing has been started.
-     */
-    private function warnProcessingStartedOn(
-        ?string $queueConnectionName,
-    ): void {
-        if ($queueConnectionName === 'sync') {
-            $message = 'Rebuilding reaction aggregates synchronously.';
-        } else {
-            $message = sprintf(
-                'Adding rebuild reaction aggregates to the `%s` queue connection.',
-                $queueConnectionName
-            );
-        }
-
-        $this->warn($message);
     }
 }

--- a/src/Console/Commands/Recount.php
+++ b/src/Console/Commands/Recount.php
@@ -80,11 +80,11 @@ final class Recount extends Command
             $queueConnectionName = $appConfigRepository->get('queue.default');
         }
 
-        $reactants = $this->collectReactants($reactableType);
-
         $this->warn(
             "Rebuilding reaction aggregates using `$queueConnectionName` queue connection."
         );
+
+        $reactants = $this->collectReactants($reactableType);
 
         $this->getOutput()->progressStart($reactants->count());
         foreach ($reactants as $reactant) {


### PR DESCRIPTION
In PR #148 we've introduced option `--queue-connection=` to run command using the queue. By default it was using `sync` connection to keep backward compatibility.

```shell
php artisan love:recount --model="App\User" --queue-connection=sync
```

In v9 it should use default queue connection from the application config when option is `null` or empty.