### PR TITLE
Add fetch reactions by Reacterable model

### DIFF
--- a/contracts/Reactant/Facades/Reactant.php
+++ b/contracts/Reactant/Facades/Reactant.php
@@ -19,9 +19,7 @@ use Cog\Contracts\Love\Reacterable\Models\Reacterable;
 
 interface Reactant
 {
-    public function getReactions(
-        Reacterable | null $reacterable = null,
-    ): iterable;
+    public function getReactions(): iterable;
 
     public function getReactionCounters(): iterable;
 

--- a/contracts/Reactant/Facades/Reactant.php
+++ b/contracts/Reactant/Facades/Reactant.php
@@ -19,7 +19,9 @@ use Cog\Contracts\Love\Reacterable\Models\Reacterable;
 
 interface Reactant
 {
-    public function getReactions(): iterable;
+    public function getReactions(
+        Reacterable | null $reacterable = null,
+    ): iterable;
 
     public function getReactionCounters(): iterable;
 

--- a/contracts/Reactant/Facades/Reactant.php
+++ b/contracts/Reactant/Facades/Reactant.php
@@ -21,6 +21,10 @@ interface Reactant
 {
     public function getReactions(): iterable;
 
+    public function getReactionsBy(
+        Reacterable $reacterable,
+    ): iterable;
+
     public function getReactionCounters(): iterable;
 
     public function getReactionCounterOfType(

--- a/contracts/Reactant/Models/Reactant.php
+++ b/contracts/Reactant/Models/Reactant.php
@@ -31,6 +31,13 @@ interface Reactant
     public function getReactions(): iterable;
 
     /**
+     * @return iterable|\Cog\Contracts\Love\Reaction\Models\Reaction[]
+     */
+    public function getReactionsBy(
+        Reacter $reacter,
+    ): iterable;
+
+    /**
      * @return iterable|\Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter[]
      */
     public function getReactionCounters(): iterable;

--- a/src/Reactant/Facades/Reactant.php
+++ b/src/Reactant/Facades/Reactant.php
@@ -34,9 +34,16 @@ final class Reactant implements
     /**
      * @return iterable|\Cog\Contracts\Love\Reaction\Models\Reaction[]
      */
-    public function getReactions(): iterable
-    {
-        return $this->reactant->getReactions();
+    public function getReactions(
+        ReacterableInterface | null $reacterable = null,
+    ): iterable {
+        if ($reacterable === null) {
+            return $this->reactant->getReactions();
+        }
+
+        return $this->reactant->getReactionsBy(
+            $reacterable->getLoveReacter(),
+        );
     }
 
     /**

--- a/src/Reactant/Facades/Reactant.php
+++ b/src/Reactant/Facades/Reactant.php
@@ -34,7 +34,8 @@ final class Reactant implements
     /**
      * @return iterable|\Cog\Contracts\Love\Reaction\Models\Reaction[]
      */
-    public function getReactions(): iterable {
+    public function getReactions(): iterable
+    {
         return $this->reactant->getReactions();
     }
 

--- a/src/Reactant/Facades/Reactant.php
+++ b/src/Reactant/Facades/Reactant.php
@@ -34,13 +34,16 @@ final class Reactant implements
     /**
      * @return iterable|\Cog\Contracts\Love\Reaction\Models\Reaction[]
      */
-    public function getReactions(
-        ReacterableInterface | null $reacterable = null,
-    ): iterable {
-        if ($reacterable === null) {
-            return $this->reactant->getReactions();
-        }
+    public function getReactions(): iterable {
+        return $this->reactant->getReactions();
+    }
 
+    /**
+     * @return iterable|\Cog\Contracts\Love\Reaction\Models\Reaction[]
+     */
+    public function getReactionsBy(
+        ReacterableInterface $reacterable,
+    ): iterable {
         return $this->reactant->getReactionsBy(
             $reacterable->getLoveReacter(),
         );

--- a/src/Reactant/Models/NullReactant.php
+++ b/src/Reactant/Models/NullReactant.php
@@ -18,6 +18,7 @@ use Cog\Contracts\Love\Reactant\Exceptions\ReactantInvalid;
 use Cog\Contracts\Love\Reactant\Models\Reactant as ReactantInterface;
 use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterInterface;
 use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalInterface;
+use Cog\Contracts\Love\Reacter\Models\Reacter;
 use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterInterface;
 use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\NullReactionCounter;
@@ -48,6 +49,12 @@ final class NullReactant implements
 
     public function getReactions(): iterable
     {
+        return new Collection();
+    }
+
+    public function getReactionsBy(
+        Reacter $reacter,
+    ): iterable {
         return new Collection();
     }
 

--- a/src/Reactant/Models/Reactant.php
+++ b/src/Reactant/Models/Reactant.php
@@ -20,6 +20,7 @@ use Cog\Contracts\Love\Reactant\ReactionCounter\Exceptions\ReactionCounterDuplic
 use Cog\Contracts\Love\Reactant\ReactionCounter\Models\ReactionCounter as ReactionCounterInterface;
 use Cog\Contracts\Love\Reactant\ReactionTotal\Exceptions\ReactionTotalDuplicate;
 use Cog\Contracts\Love\Reactant\ReactionTotal\Models\ReactionTotal as ReactionTotalInterface;
+use Cog\Contracts\Love\Reacter\Models\Reacter;
 use Cog\Contracts\Love\Reacter\Models\Reacter as ReacterInterface;
 use Cog\Contracts\Love\Reaction\Models\Reaction as ReactionInterface;
 use Cog\Contracts\Love\ReactionType\Models\ReactionType as ReactionTypeInterface;
@@ -33,6 +34,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Collection;
 
 final class Reactant extends Model implements
     ReactantInterface
@@ -94,6 +96,26 @@ final class Reactant extends Model implements
     public function getReactions(): iterable
     {
         return $this->getAttribute('reactions');
+    }
+
+    /**
+     * @return iterable|\Cog\Contracts\Love\Reaction\Models\Reaction[]
+     */
+    public function getReactionsBy(
+        Reacter $reacter,
+    ): iterable {
+        if ($reacter->isNull()) {
+            return new Collection();
+        }
+
+        // TODO: Test if relation was loaded partially
+        if ($this->relationLoaded('reactions')) {
+            return $this
+                ->getAttribute('reactions')
+                ->contains(fn (ReactionInterface $reaction) => $reaction->isByReacter($reacter));
+        }
+
+        return $this->reactions()->where('reacter_id', $reacter->getId())->get();
     }
 
     public function getReactionCounters(): iterable

--- a/tests/Unit/Reactant/Facades/ReactantTest.php
+++ b/tests/Unit/Reactant/Facades/ReactantTest.php
@@ -19,7 +19,6 @@ use Cog\Laravel\Love\Reactant\ReactionCounter\Models\NullReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\NullReactionTotal;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
-use Cog\Laravel\Love\Reacter\Models\NullReacter;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Tests\Laravel\Love\Stubs\Models\User;

--- a/tests/Unit/Reactant/Facades/ReactantTest.php
+++ b/tests/Unit/Reactant/Facades/ReactantTest.php
@@ -19,7 +19,6 @@ use Cog\Laravel\Love\Reactant\ReactionCounter\Models\NullReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\NullReactionTotal;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
-use Cog\Laravel\Love\Reacter\Models\Reacter;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Tests\Laravel\Love\Stubs\Models\User;
@@ -48,19 +47,19 @@ final class ReactantTest extends TestCase
     public function it_can_get_reactions_by_user(): void
     {
         $reactant = Reactant::factory()->create();
-        $reacter = Reacter::factory()->create();
+        $reacterable = User::factory()->create();
         $reactions = Reaction::factory()->count(2)->create([
             'reactant_id' => $reactant->getId(),
-            'reacter_id' => $reacter->getId(),
+            'reacter_id' => $reacterable->getLoveRacter()->getId(),
         ]);
         Reaction::factory()->count(3)->create([
             'reactant_id' => $reactant->getId(),
         ]);
         $reactantFacade = new ReactantFacade($reactant);
 
-        $assertReactions = $reactantFacade->getReactions();
+        $assertReactions = $reactantFacade->getReactionsBy($reacterable);
 
-        $this->assertCount(2, $reactions);
+        $this->assertCount(2, $assertReactions);
         $this->assertTrue($assertReactions->get(0)->is($reactions->get(0)));
         $this->assertTrue($assertReactions->get(1)->is($reactions->get(1)));
     }

--- a/tests/Unit/Reactant/Facades/ReactantTest.php
+++ b/tests/Unit/Reactant/Facades/ReactantTest.php
@@ -19,6 +19,7 @@ use Cog\Laravel\Love\Reactant\ReactionCounter\Models\NullReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\NullReactionTotal;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
+use Cog\Laravel\Love\Reacter\Models\Reacter;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Tests\Laravel\Love\Stubs\Models\User;
@@ -39,6 +40,27 @@ final class ReactantTest extends TestCase
 
         $assertReactions = $reactantFacade->getReactions();
 
+        $this->assertTrue($assertReactions->get(0)->is($reactions->get(0)));
+        $this->assertTrue($assertReactions->get(1)->is($reactions->get(1)));
+    }
+
+    /** @test */
+    public function it_can_get_reactions_by_user(): void
+    {
+        $reactant = Reactant::factory()->create();
+        $reacter = Reacter::factory()->create();
+        $reactions = Reaction::factory()->count(2)->create([
+            'reactant_id' => $reactant->getId(),
+            'reacter_id' => $reacter->getId(),
+        ]);
+        Reaction::factory()->count(3)->create([
+            'reactant_id' => $reactant->getId(),
+        ]);
+        $reactantFacade = new ReactantFacade($reactant);
+
+        $assertReactions = $reactantFacade->getReactions();
+
+        $this->assertCount(2, $reactions);
         $this->assertTrue($assertReactions->get(0)->is($reactions->get(0)));
         $this->assertTrue($assertReactions->get(1)->is($reactions->get(1)));
     }

--- a/tests/Unit/Reactant/Facades/ReactantTest.php
+++ b/tests/Unit/Reactant/Facades/ReactantTest.php
@@ -19,6 +19,7 @@ use Cog\Laravel\Love\Reactant\ReactionCounter\Models\NullReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\NullReactionTotal;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
+use Cog\Laravel\Love\Reacter\Models\NullReacter;
 use Cog\Laravel\Love\Reaction\Models\Reaction;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Tests\Laravel\Love\Stubs\Models\User;
@@ -50,7 +51,7 @@ final class ReactantTest extends TestCase
         $reacterable = User::factory()->create();
         $reactions = Reaction::factory()->count(2)->create([
             'reactant_id' => $reactant->getId(),
-            'reacter_id' => $reacterable->getLoveRacter()->getId(),
+            'reacter_id' => $reacterable->getLoveReacter()->getId(),
         ]);
         Reaction::factory()->count(3)->create([
             'reactant_id' => $reactant->getId(),

--- a/tests/Unit/Reactant/Models/NullReactantTest.php
+++ b/tests/Unit/Reactant/Models/NullReactantTest.php
@@ -18,9 +18,11 @@ use Cog\Laravel\Love\Reactant\Models\NullReactant;
 use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\NullReactionCounter;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\NullReactionTotal;
+use Cog\Laravel\Love\Reacter\Models\NullReacter;
 use Cog\Laravel\Love\Reacter\Models\Reacter;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Tests\Laravel\Love\Stubs\Models\Article;
+use Cog\Tests\Laravel\Love\Stubs\Models\User;
 use Cog\Tests\Laravel\Love\TestCase;
 use Illuminate\Support\Collection;
 use TypeError;
@@ -56,17 +58,21 @@ final class NullReactantTest extends TestCase
         $reactions = $reactant->getReactions();
 
         $this->assertCount(0, $reactions);
+        $this->assertInstanceOf(Collection::class, $reactions);
         $this->assertIsIterable($reactions);
     }
 
     /** @test */
-    public function it_can_get_reactions_collection(): void
+    public function it_can_get_reactions_by_user(): void
     {
         $reactant = new NullReactant(new Article());
+        $reacter = new NullReacter(new User());
 
-        $reactions = $reactant->getReactions();
+        $reactions = $reactant->getReactionsBy($reacter);
 
+        $this->assertCount(0, $reactions);
         $this->assertInstanceOf(Collection::class, $reactions);
+        $this->assertIsIterable($reactions);
     }
 
     /** @test */

--- a/tests/Unit/Reactant/Models/ReactantTest.php
+++ b/tests/Unit/Reactant/Models/ReactantTest.php
@@ -219,6 +219,7 @@ final class ReactantTest extends TestCase
         ]);
 
         $assertReactions = $reactant->getReactionsBy($reacter);
+        $this->assertCount(2, $assertReactions);
         $this->assertTrue($assertReactions->get(0)->is($reactions->get(0)));
         $this->assertTrue($assertReactions->get(1)->is($reactions->get(1)));
     }
@@ -230,7 +231,7 @@ final class ReactantTest extends TestCase
         $reactant = Reactant::factory()->create();
         $nullReacter = new NullReacter(new User());
 
-        $reactions = Reaction::factory()->count(3)->create([
+        Reaction::factory()->count(3)->create([
             'reaction_type_id' => $reactionType->getId(),
             'reactant_id' => $reactant->getId(),
         ]);

--- a/tests/Unit/Reactant/Models/ReactantTest.php
+++ b/tests/Unit/Reactant/Models/ReactantTest.php
@@ -28,6 +28,7 @@ use Cog\Laravel\Love\Reaction\Models\Reaction;
 use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Tests\Laravel\Love\Stubs\Models\Article;
 use Cog\Tests\Laravel\Love\Stubs\Models\Bot;
+use Cog\Tests\Laravel\Love\Stubs\Models\User;
 use Cog\Tests\Laravel\Love\TestCase;
 use Illuminate\Support\Facades\Event;
 use TypeError;
@@ -198,6 +199,44 @@ final class ReactantTest extends TestCase
 
         $this->assertTrue($assertReactions->get(0)->is($reactions->get(0)));
         $this->assertTrue($assertReactions->get(1)->is($reactions->get(1)));
+    }
+
+    /** @test */
+    public function it_can_get_reactions_by_reacter(): void
+    {
+        $reactionType = ReactionType::factory()->create();
+        $reactant = Reactant::factory()->create();
+        $reacter = Reacter::factory()->create();
+
+        $reactions = Reaction::factory()->count(2)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactant->getId(),
+            'reacter_id' => $reacter->getId(),
+        ]);
+        Reaction::factory()->count(3)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactant->getId(),
+        ]);
+
+        $assertReactions = $reactant->getReactionsBy($reacter);
+        $this->assertTrue($assertReactions->get(0)->is($reactions->get(0)));
+        $this->assertTrue($assertReactions->get(1)->is($reactions->get(1)));
+    }
+
+    /** @test */
+    public function it_can_get_reactions_by_null_reacter(): void
+    {
+        $reactionType = ReactionType::factory()->create();
+        $reactant = Reactant::factory()->create();
+        $nullReacter = new NullReacter(new User());
+
+        $reactions = Reaction::factory()->count(3)->create([
+            'reaction_type_id' => $reactionType->getId(),
+            'reactant_id' => $reactant->getId(),
+        ]);
+
+        $assertReactions = $reactant->getReactionsBy($nullReacter);
+        $this->assertCount(0, $assertReactions);
     }
 
     /** @test */


### PR DESCRIPTION
Feature request appeared in issue:
- #237

This is implementation of the Solution №2 from the discussion:
- https://github.com/cybercog/laravel-love/discussions/239#discussioncomment-5501195

### High-level API (preferred)

Method  `\Cog\Contracts\Love\Reactant\Facades::getReactions` signature changed:
```php
public function getReactions(
    Reacterable | null $reacterable = null,
): iterable;
```

Usage:
```php
// Get all reactions the post received
$allReactionsOnPost = $post->viaLoveReactant()->getReactions();

// Get reactions the post received from the user
$userReactionsOnPost = $post->viaLoveReactant()->getReactions($user);
```

### Low-level API

Method `\Cog\Contracts\Love\Reactant\Models\Reactant::getReactionsBy` method introduced:
```php
public function getReactionsBy(
    Reacter $reacter,
): iterable;
```

Usage:
```php
// Get reactions the post received from the user
$userReactionsOnPost = $post->getLoveReactant()->getReactionsBy($user->getLoveReacter());
```