### PR TITLE
[Debugging] introduced test case that shows join reaction counter breaks when run with count on morphables

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,13 +20,15 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
-        <env name="DB_CONNECTION" value="testing"/>
-        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_CONNECTION" value="mysql"/>
+        <env name="DB_DATABASE" value="love-test-database"/>
+        <env name="DB_PASSWORD" value="password"/>
         <server name="APP_ENV" value="testing"/>
         <server name="CACHE_DRIVER" value="array"/>
         <server name="SESSION_DRIVER" value="array"/>
         <server name="QUEUE_DRIVER" value="sync"/>
-        <server name="DB_CONNECTION" value="testing"/>
-        <server name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_CONNECTION" value="mysql"/>
+        <env name="DB_DATABASE" value="love-test-database"/>
+        <env name="DB_PASSWORD" value="password"/>
     </php>
 </phpunit>

--- a/tests/Stubs/Models/MorphableEntity.php
+++ b/tests/Stubs/Models/MorphableEntity.php
@@ -17,12 +17,8 @@ use Cog\Contracts\Love\Reactable\Models\Reactable as ReactableInterface;
 use Cog\Laravel\Love\Reactable\Models\Traits\Reactable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 
-/**
- * @method static ArticleEloquentBuilder query()
- */
-final class Article extends Model implements
+final class MorphableEntity extends Model implements
     ReactableInterface
 {
     use HasFactory;
@@ -33,7 +29,7 @@ final class Article extends Model implements
      *
      * @var string
      */
-    protected $table = 'articles';
+    protected $table = 'morphable_entities';
 
     /**
      * The attributes that are mass assignable.
@@ -43,15 +39,4 @@ final class Article extends Model implements
     protected $fillable = [
         'name',
     ];
-
-    /** @inheritDoc */
-    public function newEloquentBuilder($query): ArticleEloquentBuilder
-    {
-        return new ArticleEloquentBuilder($query);
-    }
-
-    public function morphableEntities(): MorphMany
-    {
-        return $this->morphMany(MorphableEntity::class, 'morphable');
-    }
 }

--- a/tests/database/factories/MorphableEntityFactory.php
+++ b/tests/database/factories/MorphableEntityFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Laravel Ban.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Tests\Laravel\Love\Database\Factories;
+
+use Cog\Tests\Laravel\Love\Stubs\Models\MorphableEntity;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+final class MorphableEntityFactory extends Factory
+{
+    protected $model = MorphableEntity::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+        ];
+    }
+}

--- a/tests/database/migrations/2016_09_02_173301_create_morphable_entities_table.php
+++ b/tests/database/migrations/2016_09_02_173301_create_morphable_entities_table.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Laravel Love.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('morphable_entities', function (Blueprint $table) {
+            $table->increments('id');
+            $table->morphs('morphable');
+            $table->unsignedBigInteger('love_reactant_id')->nullable();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('morphable_entities');
+    }
+};


### PR DESCRIPTION
Hi @antonkomarev, this PR is to demonstrate some breaks that are happening when the `joinReactionCounterOfType` is called with the `withCount` method on morphable relations. The issue is not apparent when run in the in-memory database but when you switch to a mysql connection it shows up.

The error that shows up is
`Illuminate\Database\QueryException: SQLSTATE[HY093]: Invalid parameter number (Connection: mysql, SQL: select `articles`.*, (select count(*) from `morphable_entities` where `articles`.`id` = `morphable_entities`.`morphable_id` and `morphable_entities`.`morphable_type` = 1) as `morphable_entities_count`, COALESCE(reaction_like.count, 0) as reaction_like_count, COALESCE(reaction_like.weight, 0) as reaction_like_weight from `articles` left join `love_reactant_reaction_counters` as `reaction_like` on `reaction_like`.`reactant_id` = `articles`.`love_reactant_id` and `reaction_like`.`reaction_type_id` = ? order by `reaction_like_count` asc)`