### PR TITLE
fix: use table names from config file

### DIFF
--- a/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
+++ b/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
@@ -11,6 +11,8 @@
 
 declare(strict_types=1);
 
+use Cog\Laravel\Love\Reactant\Models\Reactant;
+use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
@@ -38,12 +40,12 @@ return new class extends Migration
             $table
                 ->foreign('reactant_id')
                 ->references('id')
-                ->on('love_reactants')
+                ->on((new Reactant())->getTable())
                 ->onDelete('cascade');
             $table
                 ->foreign('reaction_type_id')
                 ->references('id')
-                ->on('love_reaction_types')
+                ->on((new ReactionType())->getTable())
                 ->onDelete('cascade');
         });
     }

--- a/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
+++ b/database/migrations/2018_07_25_000000_create_love_reactant_reaction_counters_table.php
@@ -12,8 +12,8 @@
 declare(strict_types=1);
 
 use Cog\Laravel\Love\Reactant\Models\Reactant;
-use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Laravel\Love\Reactant\ReactionCounter\Models\ReactionCounter;
+use Cog\Laravel\Love\ReactionType\Models\ReactionType;
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
+++ b/database/migrations/2018_07_25_001000_create_love_reactant_reaction_totals_table.php
@@ -11,6 +11,7 @@
 
 declare(strict_types=1);
 
+use Cog\Laravel\Love\Reactant\Models\Reactant;
 use Cog\Laravel\Love\Reactant\ReactionTotal\Models\ReactionTotal;
 use Cog\Laravel\Love\Support\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
@@ -32,7 +33,7 @@ return new class extends Migration
             $table
                 ->foreign('reactant_id')
                 ->references('id')
-                ->on('love_reactants')
+                ->on((new Reactant())->getTable())
                 ->onDelete('cascade');
         });
     }


### PR DESCRIPTION
There are two migrations (`love_reactant_reaction_counters` and `love_reactant_reaction_totals`) that use hardcoded table names instead of dynamically fetching table names with model's `getTable()`. This causes an error when running the migrations as those tables do not exist. This PR solves this issue by just replacing the hardcoded table names by the model's `getTable()`.